### PR TITLE
click handler + arrow back added

### DIFF
--- a/src/components/specific/files/files-manager/FilesManager.vue
+++ b/src/components/specific/files/files-manager/FilesManager.vue
@@ -1,20 +1,5 @@
 <template>
   <BIMDataCard class="files-manager" :titleHeader="$t('FilesManager.title')">
-    <template #left>
-      <BIMDataIcon
-        name="arrow"
-        size="xxs"
-        margin="10 13"
-        @click="backToParent(currentFolder)"
-        :style="{
-          cursor: currentFolder.parentId ? 'pointer' : 'initial'
-        }"
-      />
-      <FilesManagerBreadcrumb
-        :file="currentFolder"
-        @file-selected="onFileSelected"
-      />
-    </template>
     <template #content>
       <template v-if="fileStructure.children.length > 0">
         <div class="files-manager__actions">
@@ -72,6 +57,7 @@
             @file-uploaded="$emit('file-uploaded')"
             @manage-access="openAccessManager($event)"
             @selection-changed="setSelection"
+            @back-parent-folder="backToParent"
           />
         </div>
 
@@ -124,7 +110,6 @@ import FolderAccessManager from "@/components/specific/files/folder-access-manag
 import FolderCreationButton from "@/components/specific/files/folder-creation-button/FolderCreationButton";
 import FilesActionBar from "./files-action-bar/FilesActionBar";
 import FilesDeleteModal from "./files-delete-modal/FilesDeleteModal";
-import FilesManagerBreadcrumb from "./files-manager-breadcrumb/FilesManagerBreadcrumb";
 import FilesManagerOnboarding from "./files-manager-onboarding/FilesManagerOnboarding";
 
 export default {
@@ -136,7 +121,6 @@ export default {
     FolderCreationButton,
     FilesActionBar,
     FilesDeleteModal,
-    FilesManagerBreadcrumb,
     FilesManagerOnboarding
   },
   props: {

--- a/src/components/specific/files/files-manager/FilesManager.vue
+++ b/src/components/specific/files/files-manager/FilesManager.vue
@@ -1,7 +1,19 @@
 <template>
   <BIMDataCard class="files-manager" :titleHeader="$t('FilesManager.title')">
     <template #left>
-      <FilesManagerBreadcrumb :file="currentFolder" />
+      <BIMDataIcon
+        name="arrow"
+        size="xxs"
+        margin="10 13"
+        @click="backToParent(currentFolder)"
+        :style="{
+          cursor: currentFolder.parentId ? 'pointer' : 'initial'
+        }"
+      />
+      <FilesManagerBreadcrumb
+        :file="currentFolder"
+        @file-selected="onFileSelected"
+      />
     </template>
     <template #content>
       <template v-if="fileStructure.children.length > 0">
@@ -182,8 +194,13 @@ export default {
     );
     const onFileSelected = file => {
       if (file.type === FILE_TYPES.FOLDER) {
-        currentFolder.value = file;
+        currentFolder.value = handler.deserialize(file);
       }
+    };
+
+    const backToParent = file => {
+      const parentFolder = handler.parent(file);
+      currentFolder.value = handler.deserialize(parentFolder);
     };
 
     const { filteredList: displayedFiles, searchText } = useListFilter(
@@ -273,7 +290,8 @@ export default {
       onFileSelected,
       openDeleteModal,
       setSelection,
-      uploadFiles
+      uploadFiles,
+      backToParent
     };
   }
 };

--- a/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.scss
+++ b/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.scss
@@ -2,7 +2,6 @@
   &__path {
     display: inline-flex;
     align-items: center;
-    gap: 15px;
   }
 
   &__file {

--- a/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.scss
+++ b/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.scss
@@ -2,11 +2,10 @@
   &__path {
     display: inline-flex;
     align-items: center;
-    gap: calc(var(--spacing-unit) / 2);
+    gap: 15px;
   }
 
   &__file {
-    margin-left: calc(var(--spacing-unit) / 2);
     font-weight: bold;
   }
 }

--- a/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.vue
+++ b/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.vue
@@ -5,7 +5,9 @@
         <TextBox
           :text="folder.name"
           :maxLength="24"
+          @click="selectFile(folder)"
           tooltipColor="tertiary-lightest"
+          style="cursor: pointer"
         />
         <span>></span>
       </template>
@@ -30,7 +32,8 @@ export default {
       required: true
     }
   },
-  setup(props) {
+  emits: ["file-selected"],
+  setup(props, { emit }) {
     const { fileStructureHandler: handler } = useFiles();
 
     const path = ref([]);
@@ -41,8 +44,11 @@ export default {
       { immediate: true }
     );
 
+    const selectFile = folder => emit("file-selected", folder);
+
     return {
-      path
+      path,
+      selectFile
     };
   }
 };

--- a/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.vue
+++ b/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="files-manager-breadcrumb">
     <span class="files-manager-breadcrumb__path">
-      <template v-for="folder of path" :key="folder.id">
+      <template v-for="(folder, index) of path" :key="folder.id">
         <TextBox
           :text="folder.name"
           :maxLength="24"
           @click="selectFile(folder)"
           tooltipColor="tertiary-lightest"
-          style="cursor: pointer"
+          :style="{
+            cursor: 'pointer',
+            margin: index === 0 ? 'auto 15px auto 5px' : 'auto 15px'
+          }"
         />
         <span>></span>
       </template>

--- a/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.vue
+++ b/src/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb.vue
@@ -17,6 +17,7 @@
       :text="file.name"
       :maxLength="24"
       tooltipColor="tertiary-lightest"
+      :style="{ marginLeft: path.length ? '15px' : '5px' }"
     />
   </div>
 </template>
@@ -32,7 +33,7 @@ export default {
       required: true
     }
   },
-  emits: ["file-selected"],
+  emits: ["file-clicked"],
   setup(props, { emit }) {
     const { fileStructureHandler: handler } = useFiles();
 
@@ -44,7 +45,7 @@ export default {
       { immediate: true }
     );
 
-    const selectFile = folder => emit("file-selected", folder);
+    const selectFile = folder => emit("file-clicked", folder);
 
     return {
       path,

--- a/src/components/specific/files/files-table/FilesTable.vue
+++ b/src/components/specific/files/files-table/FilesTable.vue
@@ -11,13 +11,20 @@
   >
     <template #sub-header>
       <div style="display: flex; align-items: center">
-        <BIMDataIcon
-          name="arrow"
-          size="xxs"
-          margin="10 24 10 12"
-          @click="$emit('back-parent-folder', folder)"
-          :style="{ cursor: folder.parentId ? 'pointer' : 'initial' }"
-        />
+        <BIMDataButton
+          ghost
+          rounded
+          icon
+          :disabled="!folder.parentId"
+          style="margin: 5px 14px 5px 3px"
+        >
+          <BIMDataIcon
+            name="arrow"
+            size="xxs"
+            @click="$emit('back-parent-folder', folder)"
+            :style="{ cursor: folder.parentId ? 'pointer' : 'initial' }"
+          />
+        </BIMDataButton>
         <FilesManagerBreadcrumb
           :file="folder"
           @file-clicked="$emit('file-clicked', $event)"

--- a/src/components/specific/files/files-table/FilesTable.vue
+++ b/src/components/specific/files/files-table/FilesTable.vue
@@ -10,6 +10,19 @@
     :placeholder="$t('FilesTable.emptyTablePlaceholder')"
   >
     <template #sub-header>
+      <div style="display: flex; align-items: center">
+        <BIMDataIcon
+          name="arrow"
+          size="xxs"
+          margin="10 24 10 12"
+          @click="$emit('back-parent-folder', folder)"
+          :style="{ cursor: folder.parentId ? 'pointer' : 'initial' }"
+        />
+        <FilesManagerBreadcrumb
+          :file="folder"
+          @file-clicked="$emit('file-clicked', $event)"
+        />
+      </div>
       <transition-group name="list">
         <FileUploadCard
           v-for="file of fileUploads"
@@ -69,6 +82,7 @@ import columnsDef from "./columns";
 // Components
 import GenericTable from "@/components/generic/generic-table/GenericTable";
 import FileUploadCard from "@/components/specific/files/file-upload-card/FileUploadCard";
+import FilesManagerBreadcrumb from "@/components/specific/files/files-manager/files-manager-breadcrumb/FilesManagerBreadcrumb";
 import FileActionsCell from "./file-actions-cell/FileActionsCell";
 import FileLastUpdateCell from "./file-last-update-cell/FileLastUpdateCell";
 import FileNameCell from "./file-name-cell/FileNameCell";
@@ -83,7 +97,8 @@ export default {
     FileNameCell,
     FileTagsCell,
     FileTypeCell,
-    FileUploadCard
+    FileUploadCard,
+    FilesManagerBreadcrumb
   },
   props: {
     project: {
@@ -109,7 +124,8 @@ export default {
     "file-clicked",
     "file-uploaded",
     "manage-access",
-    "selection-changed"
+    "selection-changed",
+    "back-parent-folder"
   ],
   setup(props, { emit }) {
     const { locale, t } = useI18n();

--- a/src/components/specific/files/files-table/FilesTable.vue
+++ b/src/components/specific/files/files-table/FilesTable.vue
@@ -10,19 +10,18 @@
     :placeholder="$t('FilesTable.emptyTablePlaceholder')"
   >
     <template #sub-header>
-      <div style="display: flex; align-items: center">
-        <BIMDataButton
-          ghost
-          rounded
-          icon
-          :disabled="!folder.parentId"
-          style="margin: 5px 14px 5px 3px"
-        >
+      <div
+        :style="{
+          display: folder.parentId ? 'flex' : 'none',
+          alignItems: 'center'
+        }"
+      >
+        <BIMDataButton ghost rounded icon style="margin: 5px 14px 5px 3px">
           <BIMDataIcon
             name="arrow"
             size="xxs"
             @click="$emit('back-parent-folder', folder)"
-            :style="{ cursor: folder.parentId ? 'pointer' : 'initial' }"
+            style="cursor: pointer"
           />
         </BIMDataButton>
         <FilesManagerBreadcrumb


### PR DESCRIPTION
Hello World,

file-breadcrumb is now enhanced with 2 features
* It's possible to click on any folder within the breadcrumb, the user will reach the clicked folder
* An arrow back has been added, that permit to get back to the parent of the current folder

The integration is not finished yet, the breadcrumb has to be moved into the "generic-table"

Paul 