### PR TITLE
all types of documents are displayed

### DIFF
--- a/src/components/specific/files/files-manager/FilesManager.vue
+++ b/src/components/specific/files/files-manager/FilesManager.vue
@@ -169,10 +169,14 @@ export default {
       folder => {
         const childrenFolders = folder.children
           .filter(child => child.type === FILE_TYPES.FOLDER)
-          .sort((a, b) => (a.name < b.name ? -1 : 1));
+          .sort((a, b) =>
+            a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1
+          );
         const childrenFiles = folder.children
           .filter(child => child.type !== FILE_TYPES.FOLDER)
-          .sort((a, b) => (a.name < b.name ? -1 : 1));
+          .sort((a, b) =>
+            a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1
+          );
         currentFiles.value = childrenFolders.concat(childrenFiles);
       },
       { immediate: true }

--- a/src/components/specific/files/folder-selector/FolderSelector.scss
+++ b/src/components/specific/files/folder-selector/FolderSelector.scss
@@ -47,8 +47,13 @@
         background-color: var(--color-tertiary);
       }
 
-      &:hover:not(.selected) {
+      &:hover:not(.selected).folder {
         background-color: var(--color-tertiary-lightest);
+      }
+      
+      &:not(.folder) {
+        opacity: 60%;
+        cursor: initial;
       }
 
       &__name {

--- a/src/components/specific/files/folder-selector/FolderSelector.vue
+++ b/src/components/specific/files/folder-selector/FolderSelector.vue
@@ -147,7 +147,9 @@ export default {
         )
         .sort((a, b) => {
           if (isFolder(a) && !isFolder(b)) return -1;
-          return a.name < b.name ? -1 : 1;
+          if (!isFolder(a) && isFolder(b)) return 1;
+
+          return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
         })
     );
 

--- a/src/components/specific/files/folder-selector/FolderSelector.vue
+++ b/src/components/specific/files/folder-selector/FolderSelector.vue
@@ -34,13 +34,13 @@
         v-for="file of displayedFiles"
         :key="file.id"
         :class="{
-          folder: isFolderType(file),
+          folder: isFolder(file),
           selected: selectedFolder && selectedFolder.id === file.id
         }"
         @click="selectFolder(file)"
         @dblclick="enterFolder(file)"
       >
-        <BIMDataIcon v-if="isFolderType(file)" name="folder" size="xs" />
+        <BIMDataIcon v-if="isFolder(file)" name="folder" size="xs" />
         <FileIcon v-else-if="file.type === 'Ifc'" name="ifc" size="13" />
         <FileIcon v-else :name="fileExtension(file.name)" size="13" />
         <TextBox
@@ -49,7 +49,7 @@
           :maxLength="32"
         />
         <BIMDataIcon
-          v-if="isFolderType(file)"
+          v-if="isFolder(file)"
           name="chevron"
           size="xxs"
           @click.stop="enterFolder(file)"
@@ -106,8 +106,8 @@ import { computed, ref, watch } from "vue";
 
 import { useFiles } from "@/state/files";
 import { fileExtension } from "@/utils/files";
+import { isFolder } from "@/utils/file-structure";
 import FILE_PERMISSIONS from "@/config/file-permissions";
-import FILE_TYPES from "@/config/file-types";
 
 export default {
   props: {
@@ -146,7 +146,7 @@ export default {
               child.userPermission === FILE_PERMISSIONS.READ_WRITE)
         )
         .sort((a, b) => {
-          if (isFolderType(a) && !isFolderType(b)) return -1;
+          if (isFolder(a) && !isFolder(b)) return -1;
           return a.name < b.name ? -1 : 1;
         })
     );
@@ -155,8 +155,6 @@ export default {
       const activeFolder = (selectedFolder.value || currentFolder.value).id;
       return props.files.some(f => activeFolder === f.parentId);
     });
-
-    const isFolderType = file => file.type === FILE_TYPES.FOLDER;
 
     const set = () => {
       currentFolder.value = props.initialFolder;
@@ -179,7 +177,7 @@ export default {
     };
 
     const enterFolder = folder => {
-      if (!isFolderType(folder)) return;
+      if (!isFolder(folder)) return;
 
       folderPath.value.push(currentFolder.value);
       currentFolder.value = folder;
@@ -191,7 +189,7 @@ export default {
     };
 
     const selectFolder = folder => {
-      if (!isFolderType(folder)) return;
+      if (!isFolder(folder)) return;
 
       if (selectedFolder.value && selectedFolder.value.id === folder.id) {
         selectedFolder.value = null;
@@ -220,7 +218,7 @@ export default {
       submit,
       isAllowedToMoveFile,
       fileExtension,
-      isFolderType
+      isFolder
     };
   }
 };

--- a/src/components/specific/files/folder-selector/FolderSelector.vue
+++ b/src/components/specific/files/folder-selector/FolderSelector.vue
@@ -34,13 +34,13 @@
         v-for="file of displayedFiles"
         :key="file.id"
         :class="{
-          folder: file.type === 'Folder',
+          folder: isFolderType(file),
           selected: selectedFolder && selectedFolder.id === file.id
         }"
         @click="selectFolder(file)"
         @dblclick="enterFolder(file)"
       >
-        <BIMDataIcon v-if="file.type === 'Folder'" name="folder" size="xs" />
+        <BIMDataIcon v-if="isFolderType(file)" name="folder" size="xs" />
         <FileIcon v-else-if="file.type === 'Ifc'" name="ifc" size="13" />
         <FileIcon v-else :name="fileExtension(file.name)" size="13" />
         <TextBox
@@ -49,7 +49,7 @@
           :maxLength="32"
         />
         <BIMDataIcon
-          v-if="file.type === 'Folder'"
+          v-if="isFolderType(file)"
           name="chevron"
           size="xxs"
           @click.stop="enterFolder(file)"
@@ -146,7 +146,7 @@ export default {
               child.userPermission === FILE_PERMISSIONS.READ_WRITE)
         )
         .sort((a, b) => {
-          if (a.type === "Folder" && b.type !== "Folder") return -1;
+          if (isFolderType(a) && !isFolderType(b)) return -1;
           return a.name < b.name ? -1 : 1;
         })
     );
@@ -155,6 +155,8 @@ export default {
       const activeFolder = (selectedFolder.value || currentFolder.value).id;
       return props.files.some(f => activeFolder === f.parentId);
     });
+
+    const isFolderType = file => file.type === FILE_TYPES.FOLDER;
 
     const set = () => {
       currentFolder.value = props.initialFolder;
@@ -177,7 +179,7 @@ export default {
     };
 
     const enterFolder = folder => {
-      if (folder.type !== FILE_TYPES.FOLDER) return;
+      if (!isFolderType(folder)) return;
 
       folderPath.value.push(currentFolder.value);
       currentFolder.value = folder;
@@ -189,7 +191,7 @@ export default {
     };
 
     const selectFolder = folder => {
-      if (folder.type !== FILE_TYPES.FOLDER) return;
+      if (!isFolderType(folder)) return;
 
       if (selectedFolder.value && selectedFolder.value.id === folder.id) {
         selectedFolder.value = null;
@@ -217,7 +219,8 @@ export default {
       selectFolder,
       submit,
       isAllowedToMoveFile,
-      fileExtension
+      fileExtension,
+      isFolderType
     };
   }
 };

--- a/src/utils/file-structure.js
+++ b/src/utils/file-structure.js
@@ -278,8 +278,14 @@ function segregate(files) {
   };
 }
 
+function isFolder(file) { 
+  return file.type === FILE_TYPES.FOLDER
+};
+
+
 export {
   FileStructureHandler,
   getDescendants,
-  segregate
+  segregate,
+  isFolder
 };

--- a/src/utils/file-structure.js
+++ b/src/utils/file-structure.js
@@ -279,8 +279,8 @@ function segregate(files) {
 }
 
 function isFolder(file) { 
-  return file.type === FILE_TYPES.FOLDER
-};
+  return file.type === FILE_TYPES.FOLDER;
+}
 
 
 export {


### PR DESCRIPTION
Hello all!

I added the display of all types of documents into the moveTo pop-up
* Folders come first and are displayed by alphabetical order
* then the other documents, by alphabetical order as well

![Screenshot 2021-11-16 at 18 46 04](https://user-images.githubusercontent.com/64323277/142038481-f2a3faa9-1cda-46a0-bd16-57b714373d43.png)


