### PR TITLE
re-size of footer when no folder are selected

### DIFF
--- a/src/components/specific/files/folder-selector/FolderSelector.scss
+++ b/src/components/specific/files/folder-selector/FolderSelector.scss
@@ -80,11 +80,15 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    padding: 0 calc(var(--spacing-unit) / 2) var(--spacing-unit) calc(var(--spacing-unit) / 2);
+    padding: var(--spacing-unit) calc(var(--spacing-unit) / 2);
 
     &__text {
       width: 100%;
       padding: var(--spacing-unit) calc(var(--spacing-unit) / 2);
+
+      &:not(.visibility){
+        display: none;
+      }
     }
   }
 }

--- a/src/components/specific/files/folder-selector/FolderSelector.vue
+++ b/src/components/specific/files/folder-selector/FolderSelector.vue
@@ -71,7 +71,7 @@
     <div class="folder-selector__footer">
       <div
         class="folder-selector__footer__text"
-        :style="{ visibility: selectedFolder ? 'visible' : 'hidden' }"
+        :class="{ visibility: selectedFolder }"
       >
         {{ $t("FolderSelector.selectedFolder") }}:
         <TextBox


### PR DESCRIPTION
hello all,

I added a behave when no folder are selected in the move-to pop-up, see the screenshot below

Paul

before
![Screenshot 2021-11-22 at 18 16 02](https://user-images.githubusercontent.com/64323277/142907452-ac373ddb-31bb-4091-a5eb-e92511acaa65.png)
after
![Screenshot 2021-11-22 at 18 23 02](https://user-images.githubusercontent.com/64323277/142907476-5a5ebbd1-af55-448f-a814-77b64ba1a24c.png)
