### PR TITLE
positioner / modification due to getComputedStyle use

### DIFF
--- a/src/components/specific/tags/tags-item/TagsItem.scss
+++ b/src/components/specific/tags/tags-item/TagsItem.scss
@@ -72,6 +72,7 @@
 
         &__color-selector {
           position: absolute;
+          top: 0px;
           right: calc(var(--spacing-unit) * -1);
           z-index: 1;
         }

--- a/src/utils/positioner.js
+++ b/src/utils/positioner.js
@@ -6,5 +6,5 @@ export function dropdownPositioner(elRef, elToPos, yOffset = 0) {
     return `-${h + yOffset}px`;
   }
 
-  return getComputedStyle(elToPos).getPropertyValue("top") || "0px";
+  return getComputedStyle(elToPos).getPropertyValue("top");
 }


### PR DESCRIPTION
https://platform-dev-behavior-fix.bimdata.io

hello team,

Since we use getComputedStyle for the positioner function, the way of use it changed.

getComputedStyle display properties values as they are displayed in DOM.
For exemple, even if I don't set "top" property, getComputedStyle will show it value as it displayed in DOM. So if I want "top" to be equal to 0px, i have to specify it in .scss file.

Paul