### PR TITLE
ged / import ged in onboarding

### DIFF
--- a/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.scss
+++ b/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.scss
@@ -12,13 +12,19 @@
     flex-wrap: wrap;
     gap: var(--spacing-unit);
     width: 30%;
-    max-width: 475px;
+    max-width: 300px;
 
     &__dropdown {
       border-radius: 3px;
       height: 32px;
+      color: var(--color-primary);
+
+      &--no-project {
+        color: var(--color-silver-dark);
+        pointer-events: none;
+      }
+
       span {
-        color: var(--color-primary);
         margin-right: calc(var(--spacing-unit) / 2);
       }
 
@@ -33,7 +39,6 @@
           left: -2px;
           font-size: calc(var(--font-size) / 1.1);
           padding-bottom: var(--spacing-unit);
-          color: var(--color-primary);
           border: none;
 
           ul {

--- a/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.vue
+++ b/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.vue
@@ -176,8 +176,7 @@ export default {
       createFolder,
       updateUploadCount,
       uploadFile,
-      fileUploadInput,
-      console
+      fileUploadInput
     };
   }
 };

--- a/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.vue
+++ b/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.vue
@@ -27,40 +27,45 @@
       >
         {{ $t("FilesManagerOnboarding.createFolderButtonText") }}
       </BIMDataButton>
-      <!-- <BIMDataDropdownMenu
-        class="files-manager-onboarding__actions__dropdown"
-        v-click-away="close"
-        ref="dropdown"
-        width="20%"
-        height="32px"
-        directionClass="up"
-        @click="toggle"
-      >
-        <template #header>
-          <span> {{ $t("FilesManagerOnboarding.GEDStructureImport") }}</span>
-          <BIMDataIcon
-            :name="isOpen ? 'deploy' : 'chevron'"
-            fill
-            size="xxs"
-            color="primary"
-            :rotate="isOpen ? 180 : 0"
-          />
-        </template>
-        <template #element>
-          <ul
-            class="bimdata-list"
-            :style="{ maxHeight: dropdownMaxHeight + 'px' }"
-          >
-            <li
-              v-for="project in projectsTree"
-              :key="project.name"
-              @click="project.action"
+      <template v-if="project.isAdmin">
+        <BIMDataDropdownMenu
+          class="files-manager-onboarding__actions__dropdown"
+          :class="{
+            ['files-manager-onboarding__actions__dropdown--no-project']:
+              projectsTree?.length === 0
+          }"
+          v-click-away="close"
+          ref="dropdown"
+          width="20%"
+          height="32px"
+          directionClass="up"
+          @click="toggle"
+        >
+          <template #header>
+            <span> {{ $t("FilesManagerOnboarding.GEDStructureImport") }}</span>
+            <BIMDataIcon
+              :name="isOpen ? 'deploy' : 'chevron'"
+              fill
+              size="xxs"
+              :rotate="isOpen ? 180 : 0"
+            />
+          </template>
+          <template #element>
+            <ul
+              class="bimdata-list"
+              :style="{ maxHeight: dropdownMaxHeight + 'px' }"
             >
-              <BIMDataTextbox :text="project.name" />
-            </li>
-          </ul>
-        </template>
-      </BIMDataDropdownMenu> -->
+              <li
+                v-for="project in projectsTree"
+                :key="project.name"
+                @click="project.action"
+              >
+                <BIMDataTextbox :text="project.name" />
+              </li>
+            </ul>
+          </template>
+        </BIMDataDropdownMenu>
+      </template>
     </div>
     <transition name="fade">
       <div
@@ -171,7 +176,8 @@ export default {
       createFolder,
       updateUploadCount,
       uploadFile,
-      fileUploadInput
+      fileUploadInput,
+      console
     };
   }
 };

--- a/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.vue
+++ b/src/components/specific/files/files-manager/files-manager-onboarding/FilesManagerOnboarding.vue
@@ -31,7 +31,7 @@
         <BIMDataDropdownMenu
           class="files-manager-onboarding__actions__dropdown"
           :class="{
-            ['files-manager-onboarding__actions__dropdown--no-project']:
+            'files-manager-onboarding__actions__dropdown--no-project':
               projectsTree?.length === 0
           }"
           v-click-away="close"


### PR DESCRIPTION
https://platform-dev-import-ged-onboarding.bimdata.io

hello team,

The feature was not working because the code was commented, certainly due to the go-live last august

I also added some improvements
* admin constraint (if simple "user", GED import button is not displayed)
* empty project constraint (disable button if no project to import)

Paul