### PR TITLE
fix vite version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-plugin-vue": "^9.7.0",
         "prettier": "^2.7.1",
         "sass": "^1.56.1",
-        "vite": "^3.2.4",
+        "vite": "3.2.4",
         "vite-plugin-environment": "^1.1.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-vue": "^9.7.0",
     "prettier": "^2.7.1",
     "sass": "^1.56.1",
-    "vite": "^3.2.4",
+    "vite": "3.2.4",
     "vite-plugin-environment": "^1.1.3"
   }
 }


### PR DESCRIPTION
## Description
The workaround that fixes the env variables broken by the `Vite` version 3.2.5. So I set the version to `3.2.4` while waiting to find a new workaround

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] My code follows the code style of this project.
- [x] I have tested my code.
