### PR TITLE
fix(models): pdf are models by default

### DIFF
--- a/src/config/models.js
+++ b/src/config/models.js
@@ -43,7 +43,8 @@ const UPLOADABLE_EXTENSIONS = Object.freeze([
   ".dwg",
   ".dxf",
   ".ifc",
-  ".ifczip"
+  ".ifczip",
+  ".pdf"
 ]);
 
 /**
@@ -53,7 +54,6 @@ const UPLOADABLE_EXTENSIONS = Object.freeze([
 const CONVERTIBLE_EXTENSIONS = Object.freeze([
   ".jpeg",
   ".jpg",
-  ".pdf",
   ".png"
 ]);
 


### PR DESCRIPTION
https://platform-dev-pdf-actions.bimdata.io

## Description
<!--- Describe your changes in detail -->
PR d'adaptation suite à la mise de l'API: les PDF sont maintenant considérés comme des modèles au même titre que les IFC / DWG. Donc plus besoin des boutons "Définir comme modèle" / "Retirer des modèles" pour les PDF dans la GED et possibilité d'uploader des PDF directement depuis le FileUploader en haut de la vue projet.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] My code follows the code style of this project.
- [x] I have tested my code.
