### PR TITLE
create space with platform-back to register webhook

### DIFF
--- a/src/services/SpaceService.js
+++ b/src/services/SpaceService.js
@@ -54,11 +54,25 @@ class SpaceService {
   }
 
   async createSpace(space) {
-    try {
-      return await apiClient.collaborationApi.createCloud(space);
-    } catch (error) {
+    const response = await fetch(
+      `${ENV.VUE_APP_BACKEND_BASE_URL}/create-cloud/`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...apiClient.authHeader
+        },
+        body: JSON.stringify(space)
+      }
+    );
+    if (response.status !== 201) {
+      let error = "";
+      if (response.headers.get("Content-Type") === "application/json") {
+        error = await response.text();
+      }
       throw new RuntimeError(ERRORS.SPACE_CREATE_ERROR, error);
     }
+    return response.json();
   }
 
   async updateSpace(space) {


### PR DESCRIPTION
https://platform-dev-create-cloud-ptf-back.bimdata.io

## Description
Use the plaftorm-back to create a new space. This is useful for enabling plaftorm_back to register webhooks with the api.

Related to https://github.com/bimdata/platform-back/pull/53

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] My code follows the code style of this project.
- [x] I have tested my code.
- [ ] I want to run the tests for the commits of this PR
