### PR TITLE
fix: restore guest buttons

### DIFF
--- a/src/components/specific/files/files-table/FilesTable.vue
+++ b/src/components/specific/files/files-table/FilesTable.vue
@@ -8,7 +8,7 @@
     :rows="files"
     rowKey="id"
     :rowHeight="54"
-    :selectable="true"
+    :selectable="!project.isGuest"
     @selection-changed="$emit('selection-changed', $event)"
     :canDragOverRow="isFolder"
     @row-drop="onRowDrop"

--- a/src/components/specific/models/models-table/ModelsTable.vue
+++ b/src/components/specific/models/models-table/ModelsTable.vue
@@ -8,7 +8,7 @@
     rowKey="id"
     :paginated="true"
     :perPage="7"
-    :selectable="true"
+    :selectable="!project.isGuest"
     @selection-changed="$emit('selection-changed', $event)"
   >
     <template #sub-header>
@@ -43,7 +43,7 @@
     <template #cell-status="{ row: model }">
       <ModelStatusCell :project="project" :model="model" />
     </template>
-    <template v-if="!project.isGuest" #cell-actions="{ row: model }">
+    <template #cell-actions="{ row: model }">
       <ModelActionsCell
         :project="project"
         :model="model"

--- a/src/components/specific/models/models-table/model-actions-cell/ModelActionsCell.vue
+++ b/src/components/specific/models/models-table/model-actions-cell/ModelActionsCell.vue
@@ -58,7 +58,7 @@
       />
     </template>
 
-    <template v-if="model.document">
+    <template v-if="model.document && !project.isGuest">
       <BIMDataButton
         class="model-actions-cell__btn"
         data-test-id="btn-download-model"
@@ -72,6 +72,7 @@
     </template>
 
     <BIMDataButton
+      v-if="!project.isGuest"
       class="model-actions-cell__btn"
       data-test-id="btn-toggle-menu"
       :disabled="!project.isAdmin && model.document?.user_permission < 100"
@@ -83,7 +84,7 @@
       <BIMDataIconEllipsis size="l" />
     </BIMDataButton>
 
-    <transition name="fade">
+    <transition name="fade" v-if="!project.isGuest">
       <BIMDataMenu
         :menuItems="menuItems"
         class="model-actions-cell__menu"

--- a/src/views/project-board/project-bcf/ProjectBcf.vue
+++ b/src/views/project-board/project-bcf/ProjectBcf.vue
@@ -38,61 +38,59 @@
       </teleport>
     </template>
     <AppSlotContent name="project-board-action">
-      <template v-if="!project.isGuest">
-        <template v-if="project.isAdmin">
-          <BIMDataButton
-            color="primary"
-            outline
-            radius
-            icon
-            @click="openSettings"
-          >
-            <BIMDataIconSettings size="xxs" />
-          </BIMDataButton>
-        </template>
-        <template v-else>
-          <BIMDataTooltip :message="$t('ProjectBcf.onlyAdminParameters')">
-            <BIMDataButton disabled color="primary" outline radius icon>
-              <BIMDataIconSettings size="xxs" />
-            </BIMDataButton>
-          </BIMDataTooltip>
-        </template>
-        <BIMDataButton
-          fill
-          radius
-          :icon="isXL"
-          color="default"
-          width="120px"
-          @click="
-            fileUploadInput(
-              'file',
-              event => importBcfTopics(event.target.files),
-              {
-                accept: ['.bcf'],
-                multiple: true
-              }
-            )
-          "
-        >
-          <BIMDataIconImport size="xs" />
-          <span v-if="!isXL" style="margin-left: 6px">
-            {{ $t("t.import") }}
-          </span>
-        </BIMDataButton>
+      <template v-if="project.isAdmin">
         <BIMDataButton
           color="primary"
-          fill
+          outline
           radius
-          :icon="isXL"
-          width="120px"
-          @click="openTopicCreate"
+          icon
+          @click="openSettings"
         >
-          <BIMDataIconPlus size="xxxs" />
-          <span v-if="!isXL" style="margin-left: 6px">
-            {{ $t("ProjectBcf.createBcfButtonText") }}
-          </span>
+          <BIMDataIconSettings size="xxs" />
         </BIMDataButton>
       </template>
+      <template v-else>
+        <BIMDataTooltip :message="$t('ProjectBcf.onlyAdminParameters')">
+          <BIMDataButton disabled color="primary" outline radius icon>
+            <BIMDataIconSettings size="xxs" />
+          </BIMDataButton>
+        </BIMDataTooltip>
+      </template>
+      <BIMDataButton
+        fill
+        radius
+        :icon="isXL"
+        color="default"
+        width="120px"
+        @click="
+          fileUploadInput(
+            'file',
+            event => importBcfTopics(event.target.files),
+            {
+              accept: ['.bcf'],
+              multiple: true
+            }
+          )
+        "
+      >
+        <BIMDataIconImport size="xs" />
+        <span v-if="!isXL" style="margin-left: 6px">
+          {{ $t("t.import") }}
+        </span>
+      </BIMDataButton>
+      <BIMDataButton
+        color="primary"
+        fill
+        radius
+        :icon="isXL"
+        width="120px"
+        @click="openTopicCreate"
+      >
+        <BIMDataIconPlus size="xxxs" />
+        <span v-if="!isXL" style="margin-left: 6px">
+          {{ $t("ProjectBcf.createBcfButtonText") }}
+        </span>
+      </BIMDataButton>
     </AppSlotContent>
 
     <div class="project-bcf__actions">


### PR DESCRIPTION
https://platform-dev-resore-guest-buttons.bimdata.io

## Description
<!--- Describe your changes in detail -->
For Guest user project :
 - Remove checkboxs from modelManager and FileTable
 - Add 2D and 3D button to modelManager
 - BCF view: add import and create button

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] My code follows the code style of this project.
- [ ] I have tested my code.
- [x] I want to run the tests for the commits of this PR
