### PR TITLE
Configure concurency on platform-dev deployement to avoid uninstall before the end of other jobs

### DIFF
--- a/.github/workflows/dev_closed.yml
+++ b/.github/workflows/dev_closed.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: dev-${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   app: platform
 

--- a/.github/workflows/dev_opened_or_updated.yml
+++ b/.github/workflows/dev_opened_or_updated.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, edited]
 
+concurrency:
+  group: dev-${{ github.head_ref }}
+  cancel-in-progress: true
+
 env:
   app: platform
 

--- a/.github/workflows/dev_opened_or_updated.yml
+++ b/.github/workflows/dev_opened_or_updated.yml
@@ -67,6 +67,9 @@ jobs:
     runs-on: [self-hosted, common]
     needs: build-and-push
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
       - name: Login to BIMData Docker Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The goal is to avoid to have traces of platform-dev on staging when the merge of the branch happen just after a new commit push

## Description
<!--- Describe your changes in detail -->

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] My code follows the code style of this project.
- [ ] I have tested my code.
- [ ] I want to run the tests for the commits of this PR
