### PR TITLE
add height to bimdata-tree to fix search when there is vertical scrol…

### DIFF
--- a/src/components/specific/models/models-manager/pdf-manager/MetaBuildingStructurePanel.vue
+++ b/src/components/specific/models/models-manager/pdf-manager/MetaBuildingStructurePanel.vue
@@ -61,5 +61,9 @@ defineEmits(["close"]);
   .content {
     height: 100%;
   }
+
+  &:deep(.bimdata-tree) {
+    height: calc(100% - 44px);
+  }
 }
 </style>


### PR DESCRIPTION
## Description
add height to bimdata-tree to fix search when there is vertical scroll with many files

## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have tested my code.
- [ ] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
