### PR TITLE
fix: Hide tag-edit inputs for users

### DIFF
--- a/src/components/specific/tags/tags-item/TagsItem.vue
+++ b/src/components/specific/tags/tags-item/TagsItem.vue
@@ -54,7 +54,10 @@
             margin="-12px 0px 0px 0px"
           />
         </template>
-        <div class="tags-item__content__info__action">
+        <div
+          v-if="isProjectAdmin(project)"
+          class="tags-item__content__info__action"
+        >
           <template v-if="!editTagName">
             <BIMDataIconEdit
               data-test-id="btn-edit-tag-name"
@@ -120,6 +123,7 @@ import TagService from "../../../../services/TagService.js";
 import { debounce } from "../../../../utils/async.js";
 import { getBorderColor } from "../../../../utils/colors.js";
 import { dropdownPositioner } from "../../../../utils/positioner.js";
+import { useUser } from "../../../../state/user.js";
 
 export default {
   props: {
@@ -142,6 +146,8 @@ export default {
   },
   emits: ["tag-to-update", "fetch-tags", "file-updated"],
   setup(props, { emit }) {
+    const { isProjectAdmin } = useUser();
+
     const tagName = ref(props.tag.name);
     const editTagName = ref(false);
     const tagContent = ref(null);
@@ -238,7 +244,8 @@ export default {
       onSubmitTagName,
       onColorSelector,
       onDeleteTag,
-      toggle
+      toggle,
+      isProjectAdmin
     };
   }
 };

--- a/src/components/specific/tags/tags-item/TagsItem.vue
+++ b/src/components/specific/tags/tags-item/TagsItem.vue
@@ -54,44 +54,43 @@
             margin="-12px 0px 0px 0px"
           />
         </template>
-        <div
-          v-if="isProjectAdmin(project)"
-          class="tags-item__content__info__action"
-        >
-          <template v-if="!editTagName">
-            <BIMDataIconEdit
-              data-test-id="btn-edit-tag-name"
+        <div class="tags-item__content__info__action">
+          <template v-if="isProjectAdmin(project)">
+            <template v-if="!editTagName">
+              <BIMDataIconEdit
+                data-test-id="btn-edit-tag-name"
+                size="xxs"
+                fill
+                color="default"
+                margin="0 12px 0 0"
+                @click="editTagName = true"
+              />
+            </template>
+            <template v-else>
+              <BIMDataIconClose
+                size="xxs"
+                fill
+                color="default"
+                margin="0 12px 0 0"
+                @click="onCancelSubmitTagName"
+              />
+            </template>
+            <BIMDataIconDelete
+              data-test-id="btn-delete-tag"
               size="xxs"
               fill
-              color="default"
+              color="high"
               margin="0 12px 0 0"
-              @click="editTagName = true"
+              @click="isSafeZone = true"
             />
           </template>
-          <template v-else>
-            <BIMDataIconClose
-              size="xxs"
-              fill
-              color="default"
-              margin="0 12px 0 0"
-              @click="onCancelSubmitTagName"
-            />
-          </template>
-          <BIMDataIconDelete
-            data-test-id="btn-delete-tag"
-            size="xxs"
-            fill
-            color="high"
-            margin="0 12px 0 0"
-            @click="isSafeZone = true"
-          />
-
           <div
             class="tags-item__content__info__action__color"
             data-test-id="btn-edit-tag-color"
             :style="{
               'background-color': `#${tagColor}`,
-              'border-color': getBorderColor(`${tagColor}`, -50)
+              'border-color': getBorderColor(`${tagColor}`, -50),
+              cursor: isProjectAdmin(project) ? 'pointer' : 'default'
             }"
             @click="onColorSelector"
           ></div>
@@ -215,13 +214,15 @@ export default {
     };
 
     const onColorSelector = () => {
-      displayColorSelector.value = true;
-      nextTick(() => {
-        colorSelector.value.style.top = dropdownPositioner(
-          props.tagsMain,
-          colorSelector.value
-        );
-      });
+      if (isProjectAdmin(props.project)) {
+        displayColorSelector.value = true;
+        nextTick(() => {
+          colorSelector.value.style.top = dropdownPositioner(
+            props.tagsMain,
+            colorSelector.value
+          );
+        });
+      }
     };
 
     const colorSelector = ref(null);

--- a/src/components/specific/tags/tags-main/TagsMain.vue
+++ b/src/components/specific/tags/tags-main/TagsMain.vue
@@ -18,9 +18,10 @@
           </BIMDataButton>
         </div>
       </div>
-      <div v-if="isProjectAdmin(project)" class="tags-main__content__list-add">
+      <div class="tags-main__content__list-add">
         <span>{{ $t("Tag.list") }}</span>
         <BIMDataButton
+          v-if="isProjectAdmin(project)"
           data-test-id="btn-create-tag"
           color="primary"
           radius

--- a/src/components/specific/tags/tags-main/TagsMain.vue
+++ b/src/components/specific/tags/tags-main/TagsMain.vue
@@ -18,7 +18,7 @@
           </BIMDataButton>
         </div>
       </div>
-      <div class="tags-main__content__list-add">
+      <div v-if="isProjectAdmin(project)" class="tags-main__content__list-add">
         <span>{{ $t("Tag.list") }}</span>
         <BIMDataButton
           data-test-id="btn-create-tag"
@@ -72,7 +72,7 @@
       </div>
       <div data-test-id="tag-list" class="tags-main__content__tag-list">
         <div v-if="updatedTagList?.length === 0" class="empty">
-         <span> {{ $t("Tag.emptyTag") }} </span>
+          <span> {{ $t("Tag.emptyTag") }} </span>
         </div>
         <template v-else v-for="tag of updatedTagList" :key="tag.id">
           <TagsItem
@@ -97,6 +97,7 @@ import { ref, watch, onMounted } from "vue";
 import { useToggle } from "../../../../composables/toggle.js";
 import TagService from "../../../../services/TagService.js";
 import { useFiles } from "../../../../state/files.js";
+import { useUser } from "../../../../state/user.js";
 import { debounce } from "../../../../utils/async.js";
 import { getRandomHexColor } from "../../../../utils/colors.js";
 // Components
@@ -123,6 +124,7 @@ export default {
   setup(props, { emit }) {
     const { getDocument } = useFiles();
     const { isOpen: showAddTagInput, toggle: toggleAddTagInput } = useToggle();
+    const { isProjectAdmin } = useUser();
 
     const tagsDocument = ref(null);
     const tagsMain = ref({});
@@ -199,6 +201,7 @@ export default {
       updatedTagList,
       showAddTagInput,
       // methods
+      isProjectAdmin,
       toggleAddTagInput,
       addNewTag
     };


### PR DESCRIPTION
## Description

Currently users have inputs to edit tags (rename, change color, or add).
This results in an error, since only project admins have permission to perform these actions.
I have added checks in the relevant components.

## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have tested my code.
- [ ] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
