### PR TITLE
BCF: use topic guid in viewer url instead of window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bimdata/components": "1.7.4",
         "@bimdata/design-system": "2.3.0-beta.1",
         "@bimdata/typescript-fetch-api-client": "10.19.4",
-        "@bimdata/viewer": "2.10.1",
+        "@bimdata/viewer": "2.11.0-beta.1",
         "@paddle/paddle-js": "^1.4.0",
         "async": "^3.2.6",
         "dms-conversion": "^3.1.3",
@@ -1805,9 +1805,9 @@
       "integrity": "sha512-LcP/H5KVxRjL+n59810Zeulkyg0+V4A6PItS8YbWKtyDNn8Fn8R2sfJy8N/iuaeV5SHgoT9NdVUb/VfTkD4T8w=="
     },
     "node_modules/@bimdata/viewer": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@bimdata/viewer/-/viewer-2.10.1.tgz",
-      "integrity": "sha512-ntAx37YekZxh9pX6lW+OXrPpyvYsogfgTV0AkZyqNsTJUBjghhIROoTY0mt+o5SeotsOa+J807ayB+MNijsp1A=="
+      "version": "2.11.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@bimdata/viewer/-/viewer-2.11.0-beta.1.tgz",
+      "integrity": "sha512-0C0IYqm4XD1ujfEVPSbe0KzfFOhdxz5rx3lA8A6OnEpJkKc2xVfTmij/N7MvWfo1hO1B7EjLMDimlXI9cM+MVw=="
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@bimdata/components": "1.7.4",
     "@bimdata/design-system": "2.3.0-beta.1",
     "@bimdata/typescript-fetch-api-client": "10.19.4",
-    "@bimdata/viewer": "2.10.1",
+    "@bimdata/viewer": "2.11.0-beta.1",
     "@paddle/paddle-js": "^1.4.0",
     "async": "^3.2.6",
     "dms-conversion": "^3.1.3",

--- a/src/views/model-viewer/ModelViewer.vue
+++ b/src/views/model-viewer/ModelViewer.vue
@@ -134,7 +134,7 @@ export default {
       loading.value = false;
 
       if (topicGuid) {
-        bimdataViewer.mount("#viewer"); // The viewer BCFManager plugin is responsible to open the corresponding topic window/layout
+        bimdataViewer.mount("#viewer", null); // The viewer BCFManager plugin is responsible to open the corresponding topic window/layout
       } else {
         bimdataViewer.mount("#viewer", initialWindow);
       }

--- a/src/views/model-viewer/ModelViewer.vue
+++ b/src/views/model-viewer/ModelViewer.vue
@@ -60,11 +60,13 @@ export default {
 
     // Initial plugins config
     const pluginsConfig = cloneDeep(PLUGINS_CONFIG);
-    merge(pluginsConfig, {
-      bcfManager: {
-        topicGuid
-      }
-    });
+    if (topicGuid) {
+      merge(pluginsConfig, {
+        bcfManager: {
+          topicGuid
+        }
+      });
+    }
 
     // Extract space specific plugins config
     // and merges it into initial config
@@ -131,7 +133,11 @@ export default {
       );
       loading.value = false;
 
-      bimdataViewer.mount("#viewer", initialWindow);
+      if (topicGuid) {
+        bimdataViewer.mount("#viewer"); // The viewer BCFManager plugin is responsible to open the corresponding topic window/layout
+      } else {
+        bimdataViewer.mount("#viewer", initialWindow);
+      }
 
       // Keep viewer access token and locale in sync with application
       unwatchAccessToken = watch(accessToken, token => {

--- a/src/views/project-board/project-bcf/ProjectBcf.vue
+++ b/src/views/project-board/project-bcf/ProjectBcf.vue
@@ -530,6 +530,8 @@ export default {
       { immediate: true }
     );
 
+    let openingTopicViewer = false;
+
     onActivated(() => {
       currentPanel.value = "";
       currentTopic.value = null;
@@ -538,7 +540,9 @@ export default {
       currentPanel.value = "";
       currentTopic.value = null;
       closeSidePanel();
-      removeTopicGuidFromUrl();
+      if (!openingTopicViewer) {
+        removeTopicGuidFromUrl();
+      }
     });
 
     const { filteredTopics, apply: applyFilters } = useBcfFilter(topics);
@@ -721,8 +725,8 @@ export default {
     };
 
     const openTopicViewer = (topic) => {
-      let viewpoint = topic.viewpoints[0] ?? {};
-      let window = getViewpointConfig(viewpoint)?.window ?? DEFAULT_WINDOW;
+      const viewpoint = topic.viewpoints[0] ?? {};
+      const win = getViewpointConfig(viewpoint)?.window ?? DEFAULT_WINDOW;
       let modelIDs = viewpoint.model_ids ?? [];
 
       if (modelIDs.length === 0) {
@@ -736,13 +740,15 @@ export default {
         // with respect to the target window
         const models = projectModels.value
           .filter(
-            (m) => m.status === MODEL_STATUS.COMPLETED && MODEL_CONFIG[m.type].window === window
+            (m) => m.status === MODEL_STATUS.COMPLETED && MODEL_CONFIG[m.type].window === win
           )
           .sort((a, b) => (a.created_at > b.created_at ? 1 : -1));
         if (models.length > 0) {
           modelIDs.push(models[0].id);
         }
       }
+
+      openingTopicViewer = true;
 
       router.push({
         name: routeNames.modelViewer,
@@ -752,7 +758,6 @@ export default {
           modelIDs: modelIDs.join(","),
         },
         query: {
-          window: topic.bimdata_viewer_layout ? "null" : window,
           topicGuid: topic.guid,
         },
       });


### PR DESCRIPTION
https://platform-dev-viewerurltopicguid.bimdata.io

## Description

Instead of using the `window` (window name) in the viewer page url to load a BCF topic, the `topic guid` is used instead. Its allow to open the corresponding topic window/layout and share the url.

WARNING: this PR needs a viewer PR merge before : https://github.com/bimdata/viewer/pull/1221

## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] My code follows the code style of this project.
- [ ] I have tested my code.
- [ ] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
