### PR TITLE
Cleanup old assets to only keep the previous version.

### DIFF
--- a/etc/clean-previous-versions.sh
+++ b/etc/clean-previous-versions.sh
@@ -8,9 +8,9 @@ TIMESTAMP_TOLERANCE=120
 
 # -d: get directory information, not on its content
 # -l: long output,
-# --time-style=+@%s => time format is a timestamp
+# --time-style=+@%s@ => time format is a timestamp
 # the '@' are added arround the timestamp to be able to easly parse the output, that not trivial without it
-# | cut -d '@' -f 2- : keep what's after the @ we insert before the timestamp (timestamp & filename)
+# | cut -d '@' -f 2 : extract the timestamp with the help of our @
 last_build_timestamp=$(ls -dl --time-style=+@%s@ $ASSETS_PATH | cut -d '@' -f 2)
 
 # Just in case, we adjust the timestamps with an error margin, not sure if necessary

--- a/etc/clean-previous-versions.sh
+++ b/etc/clean-previous-versions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+ASSETS_PATH="/usr/share/nginx/html/assets-original"
+TIMESTAMP_TOLERANCE=120
+
+# The ASSET_PATH seams to have a modification date that match the last build
+# We extract this information and only keep the file near this date
+
+# -d: get directory information, not on its content
+# -l: long output,
+# --time-style=+@%s => time format is a timestamp
+# the '@' are added arround the timestamp to be able to easly parse the output, that not trivial without it
+# | cut -d '@' -f 2- : keep what's after the @ we insert before the timestamp (timestamp & filename)
+last_build_timestamp=$(ls -dl --time-style=+@%s@ $ASSETS_PATH | cut -d '@' -f 2)
+
+# Just in case, we adjust the timestamps with an error margin, not sure if necessary
+adjusted_timestamp=$(( last_build_timestamp - TIMESTAMP_TOLERANCE ))
+
+# Find all file in our ASSETS PATH and call stat to retrieve its timestamps (%Y) & filename (%n)
+# Use awk to only keep line with a timestamps inferiour to our reference
+# Cut on our ',' to only keep the filename on each line
+# Use xargs to run rm for each line
+find ${ASSETS_PATH} -type f -exec stat --format="%Y,%n" {} + \
+    | awk -v t="${adjusted_timestamp}" '$1 < t' \
+    | cut -d ',' -f2- \
+    | xargs -L1 rm

--- a/etc/withprevious.Dockerfile
+++ b/etc/withprevious.Dockerfile
@@ -22,6 +22,8 @@ RUN mv /opt/dist/assets /opt/dist/assets-original
 # When creating a new tag, this will fail.
 # Comment this line and the COPY --from=previous_build line
 FROM ${PREVIOUS_IMAGE}:${PREVIOUS_TAG} AS previous_build
+COPY --chmod=0744 etc/clean-previous-versions.sh /
+RUN /clean-previous-versions.sh
 
 FROM nginx:stable
 RUN rm /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
https://platform-dev-previous-asset-accumulating.bimdata.io

## Description

This fix an issue with our build that keep the previous version. In fact every version where slowly accumulating in the image. we now use a script to only copy one last previous version.

## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have tested my code.
- [ ] My code add or change i18n tokens
- [ ] I want to run the tests for the commits of this PR
