### PR TITLE
fix: added missing i18n for ProjectNotificationCard

### DIFF
--- a/src/components/specific/projects/project-notification-card/ProjectNotificationCard.vue
+++ b/src/components/specific/projects/project-notification-card/ProjectNotificationCard.vue
@@ -14,7 +14,9 @@
       <transition name="slide-fade-up">
         <div v-show="open">
           <div v-if="type === 'activity'">
-            <span>Qui reçoit les notifications ?</span>
+            <span>
+              {{ $t("ProjectOverview.notifications.settings.activity.recipientsNotificationsText") }}
+            </span>
             <BIMDataButton
               color="primary"
               fill
@@ -28,7 +30,9 @@
             </BIMDataButton>
 
             <div v-for="(labels, section) in activityOptions" :key="section">
-              <h5>{{ section }}</h5>
+              <h5>
+                {{ t(`ProjectOverview.notifications.settings.activity.${section}.title`, section) }}
+              </h5>
               <BIMDataCheckbox
                 v-for="(label, index) in labels"
                 :key="`${section}-${index}`"
@@ -69,7 +73,9 @@
           />
 
           <div class="flex items-center m-l-24 m-t-12">
-            <span>À :</span>
+            <span>
+              {{ $t("ProjectOverview.notifications.settings.general.sendAt") }}
+            </span>
             <TimePicker v-model="notificationTime" class="m-x-12" />
             <BIMDataButton
               color="primary"

--- a/src/i18n/lang/de.json
+++ b/src/i18n/lang/de.json
@@ -25,14 +25,15 @@
       "size": "Sie haben nicht mehr genug Speicherplatz."
     },
     "notifications": {
-      "title": "Einstellungen Benachrichtigung per Email",
-      "headerText": "Die Projektkonfiguration auf BIMData ermöglicht die Anpassung der Art und Häufigkeit der Benachrichtigungen für eine personalisierte Nachbearbeitung",
+      "title": "E-Mail-Benachrichtigungseinstellungen",
+      "headerText": "Passen Sie hier die Art und Häufigkeit der E-Mail-Benachrichtigungen an",
       "validateButton": "Projektkonfiguration bestätigen",
       "settings": {
         "general": {
-          "sendNever": "nie Benachrichtigungsmail senden",
-          "sendEventOccurs": "ereignisaktuell versenden",
-          "sendEvery": "eine Mail immer versenden am :",
+          "sendNever": "Keine Benachrichtigungsmails versenden",
+          "sendEventOccurs": "Sofort versenden",
+          "sendEvery": "E-Mail versenden am:",
+          "sendAt": "um:",
           "monday": "Montag",
           "tuesday": "Dienstag",
           "wednesday": "Mittwoch",
@@ -45,38 +46,36 @@
           "successDeleteNotifText": "Benachrichtigungen wurden deaktiviert.",
           "errorDeleteNotifText": "Bei der Deaktivierung der Benachrichtigungen ist ein Fehler aufgetreten."
         },
-        "bcf": {
-          "title": "Benachrichtigungen per Mail BCF"
-        },
-        "visa": {
-          "title": "Benachrichtigungen per Mail VISA"
-        },
         "activity": {
-          "title": "Benachrichtigungen Projektaktivität",
-          "recipientsNotificationsButton": "Empfänger der Benachrichtigungen",
+          "title": "Projektaktivität",
+          "recipientsNotificationsText": "Wer erhält die Benachrichtigungen?",
+          "recipientsNotificationsButton": "Empfänger",
           "ged": {
-            "fileUpload": "eine Datei ablegen",
-            "fileDeletion": "eine Datei löschen",
-            "newVersion": "neue Version",
-            "folderCreation": "Ordner erstellen",
-            "folderDeletion": "Ordner löschen"
+            "title": "Dateisystem",
+            "fileUpload": "Datei abgelegt",
+            "fileDeletion": "Datei gelöscht",
+            "newVersion": "Neue Version",
+            "folderCreation": "Ordner erstellt",
+            "folderDeletion": "Ordner gelöscht"
           },
           "visa": {
-            "title": "Benachrichtigungen per Mail VISA",
-            "visaCreation": "Visa erstellen",
-            "visaDeletion": "Visa löschen",
-            "visaValidation": "Visa bestätigen",
-            "visaRejection": "Visa ablehnen"
+            "title": "VISA",
+            "visaCreation": "Visa erstellt",
+            "visaDeletion": "Visa gelöscht",
+            "visaValidation": "Visa bestätigt",
+            "visaRejection": "Visa abgelehnt"
           },
           "bcf": {
-            "bcfCreation": "BCF erstellen",
-            "bcfDeletion": "BCF löschen"
+            "title": "BCF",
+            "bcfCreation": "BCF erstellt",
+            "bcfDeletion": "BCF gelöscht"
           },
           "otherEvents": {
-            "acceptInvit": "Einladung annehmen",
-            "removeModels": "Aus den Projektvorlagen löschen",
-            "createMetaBuilding": "meta-building erstellen",
-            "deleteMetaBuilding": "meta-building löschen"
+            "title": "Sonstige Ereignisse",
+            "acceptInvit": "Einladung angenommen",
+            "removeModels": "Modell entfernt",
+            "createMetaBuilding": "meta-building erstellt",
+            "deleteMetaBuilding": "meta-building gelöscht"
           }
         }
       },

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -33,6 +33,7 @@
           "sendNever": "Never send notification emails",
           "sendEventOccurs": "When the event occurs",
           "sendEvery": "Send an email every:",
+          "sendAt": "at:",
           "monday": "Monday",
           "tuesday": "Tuesday",
           "wednesday": "Wednesday",
@@ -45,16 +46,12 @@
           "successDeleteNotifText": "Notifications have been disabled.",
           "errorDeleteNotifText": "An error occurred while disabling notifications."
         },
-        "bcf": {
-          "title": "BCF Email Notifications"
-        },
-        "visa": {
-          "title": "VISA Email Notifications"
-        },
         "activity": {
           "title": "Project activity notifications",
+          "recipientsNotificationsText": "Who receives notifications?",
           "recipientsNotificationsButton": "Notification recipients",
           "ged": {
+            "title": "File system",
             "fileUpload": "File upload",
             "fileDeletion": "File deletion",
             "newVersion": "New version",
@@ -62,19 +59,21 @@
             "folderDeletion": "Folder deletion"
           },
           "visa": {
-            "title": "Visa email notifications",
+            "title": "Visa",
             "visaCreation": "Visa creation",
             "visaDeletion": "Visa deletion",
             "visaValidation": "Visa approval",
             "visaRejection": "Visa rejection"
           },
           "bcf": {
+            "title": "BCF",
             "bcfCreation": "BCF creation",
             "bcfDeletion": "BCF deletion"
           },
           "otherEvents": {
+            "title": "Other events",
             "acceptInvit": "Invitation acceptance",
-            "removeModels": "Remove models",
+            "removeModels": "Models removed",
             "createMetaBuilding": "Meta-building creation",
             "deleteMetaBuilding": "Meta-building deletion"
           }

--- a/src/i18n/lang/es.json
+++ b/src/i18n/lang/es.json
@@ -33,6 +33,7 @@
           "sendNever": "Nunca enviar correos electrónicos de notificación",
           "sendEventOccurs": "En el momento en que ocurre el evento",
           "sendEvery": "Enviar un correo electrónico cada:",
+          "sendAt": "a las:",
           "monday": "Lunes",
           "tuesday": "Martes",
           "wednesday": "Miércoles",
@@ -45,16 +46,12 @@
           "successDeleteNotifText": "Se han desactivado las notificaciones.",
           "errorDeleteNotifText": "Se ha producido un error al desactivar las notificaciones."
         },
-        "bcf": {
-          "title": "Notificaciones por correo electrónico de BCF"
-        },
-        "visa": {
-          "title": "Notificaciones por correo electrónico de VISA"
-        },
         "activity": {
           "title": "Notificaciones de actividad del proyecto",
+          "recipientsNotificationsText": "¿Quién recibe las notificaciones?",
           "recipientsNotificationsButton": "Destinatarios de las notificaciones",
           "ged": {
+            "title": "Sistema de archivos",
             "fileUpload": "Enviar un archivo",
             "fileDeletion": "Eliminar un archivo",
             "newVersion": "Versión nueva",
@@ -62,17 +59,19 @@
             "folderDeletion": "Eliminar carpeta"
           },
           "visa": {
-            "title": "Notificaciones por correo electrónico de VISA",
+            "title": "VISA",
             "visaCreation": "Crear Visa",
             "visaDeletion": "Eliminar Visa",
             "visaValidation": "Validar Visa",
             "visaRejection": "Denegación de Visa"
           },
           "bcf": {
+            "title": "BCF",
             "bcfCreation": "Crear BCF",
             "bcfDeletion": "Eliminar BCF"
           },
           "otherEvents": {
+            "title": "Otros eventos",
             "acceptInvit": "Aceptar invitación",
             "removeModels": "Eliminar plantillas",
             "createMetaBuilding": "Crear meta-building",

--- a/src/i18n/lang/fr.json
+++ b/src/i18n/lang/fr.json
@@ -95,6 +95,7 @@
           "sendNever": "Ne jamais envoyer de mail de notification",
           "sendEventOccurs": "Au moment où l'événement se produit",
           "sendEvery": "Envoyer un mail tous les :",
+          "sendAt": "À:",
           "monday": "Lundi",
           "tuesday": "Mardi",
           "wednesday": "Mercredi",
@@ -107,16 +108,12 @@
           "successDeleteNotifText": "Les notifications ont été désactivées.",
           "errorDeleteNotifText": "Une erreur est survenue lors de la désactivation des notifications."
         },
-        "bcf": {
-          "title": "Notifications mail BCF"
-        },
-        "visa": {
-          "title": "Notifications mail VISA"
-        },
         "activity": {
           "title": "Notifications activité projet",
+          "recipientsNotificationsText": "Qui reçoit les notifications?",
           "recipientsNotificationsButton": "Destinataires des notifications",
           "ged": {
+            "title": "GED",
             "fileUpload": "Dépôt d'un fichier",
             "fileDeletion": "Suppression d'un fichier",
             "newVersion": "Nouvelle version",
@@ -124,17 +121,19 @@
             "folderDeletion": "Suppression dossier"
           },
           "visa": {
-            "title": "Notifications mail VISA",
+            "title": "VISA",
             "visaCreation": "Création de Visa",
             "visaDeletion": "Suppression Visa",
             "visaValidation": "Validation Visa",
             "visaRejection": "Refus Visa"
           },
           "bcf": {
+            "title": "BCF",
             "bcfCreation": "Création BCF",
             "bcfDeletion": "Suppression BCF"
           },
           "otherEvents": {
+            "title": "Autres évènements",
             "acceptInvit": "Acceptation d’invitation",
             "removeModels": "Retirer des modèles",
             "createMetaBuilding": "Création méta-building",

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -9,24 +9,24 @@ export const WEEK_DAYS = [
 ];
 
 export const RAW_ACTIVITY_OPTIONS = {
-  GED: [
+  ged: [
     "ged.fileUpload",
     "ged.fileDeletion",
     // "ged.newVersion",
     "ged.folderCreation",
     "ged.folderDeletion",
   ],
-  Visa: [
+  visa: [
     "visa.visaCreation",
     "visa.visaDeletion",
     "visa.visaValidation",
     "visa.visaRejection",
   ],
-  BCF: [
+  bcf: [
     "bcf.bcfCreation",
     "bcf.bcfDeletion",
   ],
-  "Autres évènements": [
+  otherEvents: [
     "otherEvents.acceptInvit",
     // "otherEvents.removeModels",
     "otherEvents.createMetaBuilding",


### PR DESCRIPTION
## Description
Hi, we recently merged the bimdata release into our platform and I had to fix some i18n issues for the new Project Notification Card. So I decided to created a PR to fix it in the bimdata platform too

<!--- Describe your changes in detail -->

- added new i18n tokens
  - `ProjectOverview.notifications.settings.activity.recipientsNotificationsText`
  - `ProjectOverview.notifications.settings.activity.[ged/visa/bcf/otherEvents].title`
  - `ProjectOverview.notifications.settings.general.sendAt`
- adjusted the German translations
- removed unused/duplicate i18n tokens
  - `ProjectOverview.notifications.settings.[bcf/visa].title`
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

before/after

<img width="380" alt="image" src="https://github.com/user-attachments/assets/626166b6-0f1f-4c70-aa3e-ac6936d09432" />
<img width="380" alt="image" src="https://github.com/user-attachments/assets/5d0ce6fb-f736-47de-bfe9-e72a5f0ede5d" />


## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [ ] I have tested my code.
- [x] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
