### PR TITLE
MINOR: feat(invitation): send multiple invitation at once

### DIFF
--- a/src/components/specific/subscriptions/space-creator/SpaceCreator.vue
+++ b/src/components/specific/subscriptions/space-creator/SpaceCreator.vue
@@ -116,7 +116,7 @@ export default {
         newSpaceLoading.value = true;
 
         // TODO: Try to fix/improve
-        // Here we set both `organizationId` and `organization.id`
+        // Here we set both `organization_id` and `organization.id`
         // because they are both used elsewhere in the code.
         // Setting only one of the two would break in some cases.
         // More specifically:
@@ -144,10 +144,10 @@ export default {
       // References
       newSpace,
       newSpaceLoading,
-      openBillingAccountModal,
       orga,
       spaceNameInput,
       // Methods
+      openBillingAccountModal,
       submit,
       updateOrga
     };

--- a/src/components/specific/users/invitation-form/InvitationForm.vue
+++ b/src/components/specific/users/invitation-form/InvitationForm.vue
@@ -7,17 +7,13 @@
         class="invitation-form__input__email"
         :placeholder="$t('InvitationForm.emailInputPlaceholder')"
         v-model="email"
-        :error="hasError"
-        :errorMessage="
-          userAlreadyExist
-            ? $t('InvitationForm.userAlreadyExistInputErrorMessage')
-            : $t('InvitationForm.emailInputErrorMessage')
-        "
+        :error="errorMessage !== ''"
+        :errorMessage="errorMessage"
         @keyup.enter.stop="submit"
         margin="0px"
       />
       <BIMDataSelect
-        v-if="project"
+        v-if="roleSelector"
         class="invitation-form__input__role"
         width="180px"
         :label="$t('InvitationForm.roleInputLabel')"
@@ -26,7 +22,7 @@
         v-model="role"
       />
     </div>
-    <BIMDataButton class="invitation-form__btn-cancel" width="80px" ghost radius @click="close">
+    <BIMDataButton class="invitation-form__btn-cancel" width="80px" ghost radius @click="cancel">
       {{ $t("t.cancel") }}
     </BIMDataButton>
     <BIMDataButton
@@ -46,11 +42,9 @@
 <script>
 import { onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import { useAppNotification } from "../../app/app-notification/app-notification.js";
 import { PROJECT_ROLE } from "../../../../config/projects.js";
-import { useProjects } from "../../../../state/projects.js";
-import { useSpaces } from "../../../../state/spaces.js";
 import { debounce } from "../../../../utils/async.js";
+import { parseEmails } from "../../../../utils/users.js";
 
 const roleList = [
   { id: "admin", value: PROJECT_ROLE.ADMIN },
@@ -60,34 +54,26 @@ const roleList = [
 
 export default {
   props: {
-    space: {
-      type: Object,
-      default: null,
+    roleSelector: {
+      type: Boolean,
+      default: false,
     },
-    project: {
-      type: Object,
-      default: null,
-    },
-    users: {
-      type: Array,
-      default: () => [],
-    },
-    currentTab: {
+    error: {
       type: String,
-      default: "admins",
-    },
+      default: ""
+    }
   },
-  emits: ["close", "success"],
+  emits: ["cancel", "submit"],
   setup(props, { emit }) {
     const { locale, t } = useI18n();
-    const { pushNotification } = useAppNotification();
-    const { sendSpaceInvitation, updateSpaceUser, spaceUsers } = useSpaces();
-    const { sendProjectInvitation } = useProjects();
+
+    const emailInput = ref(null);
+    const email = ref("");
 
     const roleOptions = ref([]);
     const role = ref(null);
     watch(
-      [() => props.space, () => props.project, () => locale.value],
+      locale,
       () => {
         let availableRoles = roleList;
 
@@ -101,76 +87,38 @@ export default {
       { immediate: true }
     );
 
-    const emailInput = ref(null);
-    const email = ref("");
-    const hasError = ref(false);
-    const userAlreadyExist = ref(false);
+    const errorMessage = ref("");
+    watch(
+      () => props.error,
+      msg => {
+        errorMessage.value = msg;
+      },
+      { immediate: true }
+    );
 
     const reset = () => {
       email.value = "";
-      hasError.value = false;
+      errorMessage.value = "";
     };
 
     const submit = debounce(async () => {
-      let currentUser;
-      if (email.value) {
-        if (props.users.map((user) => user.email).includes(email.value)) {
-          emailInput.value.focus();
-          hasError.value = true;
-          userAlreadyExist.value = true;
-        } else {
-          userAlreadyExist.value = false;
-          if (props.project) {
-            await sendProjectInvitation(props.project, {
-              email: email.value,
-              role: role.value.value,
-            });
-          } else if (props.space) {
-            currentUser = spaceUsers.value.find((user) => user.email === email.value);
-            if (currentUser) {
-              await updateSpaceUser(props.space, {
-                ...currentUser,
-                cloud_role: 100,
-              });
-            } else {
-              if (props.currentTab === "users") {
-                await sendSpaceInvitation(props.space, {
-                  email: email.value,
-                  in_all_projects: true,
-                  project_role: 50,
-                  role: 50,
-                });
-              } else {
-                await sendSpaceInvitation(props.space, {
-                  email: email.value,
-                });
-              }
-            }
-          }
-          pushNotification(
-            {
-              type: "success",
-              title: t("t.success"),
-              message: t(
-                currentUser
-                  ? "InvitationForm.successUsertoAdmin"
-                  : "InvitationForm.successNotifText"
-              ),
-            },
-            2500
-          );
-          reset();
-          emit("success");
-        }
-      } else {
+      errorMessage.value = "";
+
+      if (!email.value) {
         emailInput.value.focus();
-        hasError.value = true;
+        errorMessage.value = t("InvitationForm.emailInputErrorMessage");
+        return;
       }
+
+      const emails = parseEmails(email.value);
+
+      emit("submit", { emails, role: role.value.value });
+      reset();
     }, 500);
 
-    const close = () => {
+    const cancel = () => {
+      emit("cancel");
       reset();
-      emit("close");
     };
 
     onMounted(() => {
@@ -181,12 +129,11 @@ export default {
       // References
       email,
       emailInput,
-      hasError,
-      userAlreadyExist,
+      errorMessage,
       role,
       roleOptions,
       // Methods
-      close,
+      cancel,
       submit,
     };
   },

--- a/src/components/specific/users/invitation-form/ProjectInvitationForm.vue
+++ b/src/components/specific/users/invitation-form/ProjectInvitationForm.vue
@@ -1,0 +1,58 @@
+<script setup>
+import { eachLimit } from "async";
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useProjects } from "../../../../state/projects.js";
+import { useAppNotification } from "../../app/app-notification/app-notification.js";
+
+import InvitationForm from "./InvitationForm.vue";
+
+const { t } = useI18n();
+const { pushNotification } = useAppNotification();
+const { sendProjectInvitation } = useProjects();
+
+const props = defineProps({
+  project: {
+    type: Object,
+    required: true,
+  },
+  users: {
+    type: Array,
+    default: () => [],
+  },
+});
+
+const emit = defineEmits(["close", "success"]);
+
+const errorMessage = ref("");
+
+const submit = async ({ emails, role }) => {
+  const existingEmails = props.users.map(user => user.email);
+
+  if (emails.some(eml => existingEmails.includes(eml))) {
+    errorMessage.value = t("InvitationForm.userAlreadyExistInputErrorMessage");
+    return;
+  }
+
+  await eachLimit(emails, 10, async eml => {
+    await sendProjectInvitation(props.project, { email: eml, role });
+  });
+
+  pushNotification({
+      type: "success",
+      title: t("t.success"),
+      message: t("InvitationForm.successNotifText"),
+  }, 2500);
+
+  emit("success");
+};
+</script>
+
+<template>
+  <InvitationForm
+    :role-selector="true"
+    :error="errorMessage"
+    @cancel="$emit('close')"
+    @submit="submit"
+  />
+</template>

--- a/src/components/specific/users/invitation-form/SpaceInvitationForm.vue
+++ b/src/components/specific/users/invitation-form/SpaceInvitationForm.vue
@@ -1,0 +1,70 @@
+<script setup>
+import { eachLimit } from "async";
+import { useI18n } from "vue-i18n";
+import { useSpaces } from "../../../../state/spaces.js";
+import { useAppNotification } from "../../app/app-notification/app-notification.js";
+
+import InvitationForm from "./InvitationForm.vue";
+
+const { t } = useI18n();
+const { pushNotification } = useAppNotification();
+const { sendSpaceInvitation, updateSpaceUser } = useSpaces();
+
+const props = defineProps({
+  space: {
+    type: Object,
+    required: true,
+  },
+  users: {
+    type: Array,
+    default: () => [],
+  },
+  admin: {
+    type: Boolean,
+    default: false,
+  }
+});
+
+const emit = defineEmits(["close", "success"]);
+
+const submit = async ({ emails }) => {
+  let isExistingUsersOnly = true;
+
+  await eachLimit(emails, 10, async eml => {
+    const user = props.users.find(user => user.email === eml);
+    if (user) {
+      await updateSpaceUser(props.space, { ...user, cloud_role: 100 });
+      return;
+    }
+
+    isExistingUsersOnly = false;
+    if (props.admin) {
+      await sendSpaceInvitation(props.space, { email: eml });
+    } else {
+      await sendSpaceInvitation(props.space, {
+        email: eml,
+        in_all_projects: true,
+        project_role: 50,
+        role: 50,
+      });
+    }
+  });
+
+  pushNotification(
+    {
+      type: "success",
+      title: t("t.success"),
+      message: t(
+        isExistingUsersOnly
+          ? "InvitationForm.successUserToAdmin"
+          : "InvitationForm.successNotifText"
+      ),
+    },
+    2500
+  );
+};
+</script>
+
+<template>
+  <InvitationForm @cancel="$emit('close')" @submit="submit" />
+</template>

--- a/src/components/specific/users/project-users-manager/ProjectUsersManager.vue
+++ b/src/components/specific/users/project-users-manager/ProjectUsersManager.vue
@@ -33,7 +33,7 @@
                   clear
                 />
 
-                <InvitationForm
+                <ProjectInvitationForm
                   v-if="showInvitationForm"
                   key="invitation-form"
                   :project="project"
@@ -78,14 +78,14 @@ import { useUser } from "../../../../state/user.js";
 import { wait } from "../../../../utils/async.js";
 // Components
 import InvitationCard from "../invitation-card/InvitationCard.vue";
-import InvitationForm from "../invitation-form/InvitationForm.vue";
+import ProjectInvitationForm from "../invitation-form/ProjectInvitationForm.vue";
 import UserCard from "../user-card/UserCard.vue";
 import UsersManagerOnboarding from "./users-manager-onboarding/UsersManagerOnboarding.vue";
 
 export default {
   components: {
     InvitationCard,
-    InvitationForm,
+    ProjectInvitationForm,
     UserCard,
     UsersManagerOnboarding
   },

--- a/src/components/specific/users/project-users-manager/users-manager-onboarding/UsersManagerOnboarding.vue
+++ b/src/components/specific/users/project-users-manager/users-manager-onboarding/UsersManagerOnboarding.vue
@@ -23,7 +23,7 @@
         v-show="showInvitationForm"
         class="users-manager-onboarding__overlay"
       >
-        <InvitationForm
+        <ProjectInvitationForm
           class="users-manager-onboarding__overlay__invitation-form"
           :project="project"
           @close="closeInvitationForm"
@@ -38,7 +38,7 @@
 import { useToggle } from "../../../../../composables/toggle.js";
 import { useUser } from "../../../../../state/user.js";
 // Components
-import InvitationForm from "../../invitation-form/InvitationForm.vue";
+import ProjectInvitationForm from "../../invitation-form/ProjectInvitationForm.vue";
 import UsersManagerOnboardingImage from "./UsersManagerOnboardingImage.vue";
 
 defineProps({

--- a/src/components/specific/users/space-users-manager/SpaceUsersManager.vue
+++ b/src/components/specific/users/space-users-manager/SpaceUsersManager.vue
@@ -13,9 +13,10 @@
 
     <transition name="fade" mode="out-in">
       <template v-if="showInvitationForm">
-        <InvitationForm
-          :currentTab="currentTab"
+        <SpaceInvitationForm
           :space="space"
+          :users="users"
+          :admin="currentTab === 'admins'"
           @close="closeInvitationForm"
           @success="onInvitationSuccess"
         />
@@ -60,7 +61,7 @@ import { useSpaces } from "../../../../state/spaces.js";
 import { wait } from "../../../../utils/async.js";
 // Components
 import InvitationCard from "../invitation-card/InvitationCard.vue";
-import InvitationForm from "../invitation-form/InvitationForm.vue";
+import SpaceInvitationForm from "../invitation-form/SpaceInvitationForm.vue";
 import UserCard from "../user-card/UserCard.vue";
 
 const tabsDef = [{ id: "admins" }, { id: "users" }];
@@ -68,7 +69,7 @@ const tabsDef = [{ id: "admins" }, { id: "users" }];
 export default {
   components: {
     InvitationCard,
-    InvitationForm,
+    SpaceInvitationForm,
     UserCard,
   },
   props: {
@@ -116,9 +117,7 @@ export default {
 
     const list = computed(() => {
       if (currentTab.value === "admins") {
-        return props.invitations
-          .filter((invitation) => invitation.role === 100)
-          .concat(admins.value);
+        return props.invitations.filter((invitation) => invitation.role === 100).concat(admins.value);
       } else {
         return props.invitations.filter((invitation) => invitation.role === 50).concat(users.value);
       }

--- a/src/i18n/lang/de.json
+++ b/src/i18n/lang/de.json
@@ -217,7 +217,7 @@
     },
     "submitButtonText": "Einladen",
     "successNotifText": "Einladung versendet",
-    "successUsertoAdmin": "Der Nutzer wurde zum Administrator befördert.",
+    "successUserToAdmin": "Der Nutzer wurde zum Administrator befördert.",
     "userAlreadyExistInputErrorMessage": "Der Nutzer ist bereits in Ihren Projekt."
   },
   "ModelActionsCell": {

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -217,7 +217,7 @@
     },
     "submitButtonText": "Send invitation",
     "successNotifText": "Invitation sent",
-    "successUsertoAdmin": "The user has now admin role",
+    "successUserToAdmin": "The user has now admin role",
     "userAlreadyExistInputErrorMessage": "User is already in the project"
   },
   "ModelActionsCell": {

--- a/src/i18n/lang/es.json
+++ b/src/i18n/lang/es.json
@@ -217,7 +217,7 @@
     },
     "submitButtonText": "Invitar",
     "successNotifText": "Invitación enviada",
-    "successUsertoAdmin": "El usuario ha sido ascendido a administrador",
+    "successUserToAdmin": "El usuario ha sido ascendido a administrador",
     "userAlreadyExistInputErrorMessage": "El usuario ya está en su proyecto"
   },
   "ModelActionsCell": {

--- a/src/i18n/lang/fr.json
+++ b/src/i18n/lang/fr.json
@@ -318,7 +318,7 @@
     },
     "submitButtonText": "Inviter",
     "successNotifText": "Invitation envoyée",
-    "successUsertoAdmin": "L'utilisateur a été promu administrateur"
+    "successUserToAdmin": "L'utilisateur a été promu administrateur"
   },
   "ModelActionsCell": {
     "addTagsButtonText": "Ajouter des tags"

--- a/src/i18n/lang/it.json
+++ b/src/i18n/lang/it.json
@@ -139,7 +139,7 @@
     },
     "submitButtonText": "Invia invito",
     "successNotifText": "Invito spedito",
-    "successUsertoAdmin": "L'utente è stato promosso ad amministratore"
+    "successUserToAdmin": "L'utente è stato promosso ad amministratore"
   },
   "ModelActionsCell": {
     "addTagsButtonText": "Aggiungi tag"

--- a/src/i18n/lang/nl.json
+++ b/src/i18n/lang/nl.json
@@ -135,8 +135,7 @@
       "guest": "Gast"
     },
     "submitButtonText": "Uitnodiging versturen",
-    "successNotifText": "Uitnodiging verzonden",
-    "successUsertoAdmin": ""
+    "successNotifText": "Uitnodiging verzonden"
   },
   "ModelActionsCell": {
     "addTagsButtonText": "Labels toevoegen"

--- a/src/i18n/lang/no.json
+++ b/src/i18n/lang/no.json
@@ -135,8 +135,7 @@
       "guest": "Gjest"
     },
     "submitButtonText": "Send invitasjon",
-    "successNotifText": "Invitasjon sendt",
-    "successUsertoAdmin": ""
+    "successNotifText": "Invitasjon sendt"
   },
   "ModelActionsCell": {
     "addTagsButtonText": "Legg til tags"

--- a/src/utils/users.js
+++ b/src/utils/users.js
@@ -1,3 +1,7 @@
+function parseEmails(str) {
+  return str.replace(";", ",").split(",").map(email => email.trim());
+}
+
 function fullName({ firstname, lastname }) {
   return firstname || lastname ? `${firstname} ${lastname}` : "";
 }
@@ -6,4 +10,4 @@ function sortUsers(users) {
   return users.sort((a, b) => fullName(a) < fullName(b) ? -1 : 1);
 }
 
-export { fullName, sortUsers };
+export { parseEmails, fullName, sortUsers };


### PR DESCRIPTION
https://platform-dev-multiple-invitations.bimdata.io

## Description

<!--- Describe your changes in detail -->

Currently invitations can only be sent one at a time, which can be cumbersome when you need to invite a list of user.
This PR add the ability to send multiple invitations simultaneously by specifying a list of emails separated by commas (**,**) or semi-colons (**;**).

## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] My code follows the code style of this project.
- [ ] I have tested my code.
- [ ] My code add or change i18n tokens
- [ ] I want to run the tests for the commits of this PR
