### PR TITLE
feat(activity): add types, users, and date range filters to activity history

### DIFF
--- a/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.css
+++ b/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.css
@@ -1,6 +1,7 @@
 .history-activity-panel {
-  height: calc(100vh - 44px - 40px - 12px - 12px);
-  overflow: auto;
+  height: calc(100% - 40px);
+  display: flex;
+  flex-direction: column;
   .header {
     h3 {
       margin-bottom: 12px;
@@ -19,8 +20,12 @@
       }
     }
   }
+  .content {
+    flex: 1;
+    overflow: auto;
+  }
   .day-group {
-    margin-top: 20px;
+    margin-top: var(--spacing-unit);
     .day-title {
       font-size: 13px;
       color: var(--color-granite);

--- a/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.css
+++ b/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.css
@@ -7,13 +7,16 @@
       font-size: 18px;
     }
   }
-  .input-search {
-    border: 1px solid transparent;
-    border-radius: 3px;
-    &.focus {
-      background-color: var(--color-silver-light);
-      box-shadow: none;
-      border: 1px solid #efefef;
+  .actions {
+    gap: 6px;
+    .input-search {
+      border: 1px solid transparent;
+      border-radius: 3px;
+      &.focus {
+        background-color: var(--color-silver-light);
+        box-shadow: none;
+        border: 1px solid #efefef;
+      }
     }
   }
   .day-group {

--- a/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.vue
+++ b/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.vue
@@ -1,40 +1,44 @@
 <template>
   <div class="history-activity-panel">
-    <div class="header">
-      <h3>{{ $t("ProjectOverview.activity.title") }}</h3>
-    </div>
+    <div class="m-b-12">
+      <div class="header">
+        <h3>{{ $t("ProjectOverview.activity.title") }}</h3>
+      </div>
 
-    <div class="actions flex">
-      <BIMDataSearch
-        class="input-search"
-        width="95%"
-        :placeholder="$t('t.search')"
-        v-model="searchText"
-        clear
-        color="primary"
-      />
-      <ActivityFilters
-        v-model="filters"
-        :availableUsers="availableUsers"
-        :availableActions="availableActions"
-      />
-    </div>
-
-    <template v-if="hasDisplayedLogs">
-      <div v-for="(logs, day) in displayedGroupedLogs" :key="day" class="day-group">
-        <div class="day-title">{{ day }}</div>
-        <ActivityItem
-          v-for="log in logs"
-          :key="log.id"
-          :log="log"
-          :formatTimeAgo="formatTimeAgo"
-          @go-folder="$emit('go-folder', $event)"
+      <div class="actions flex">
+        <BIMDataSearch
+          class="input-search"
+          width="95%"
+          :placeholder="$t('t.search')"
+          v-model="searchText"
+          clear
+          color="primary"
+        />
+        <ActivityFilters
+          v-model="filters"
+          :availableUsers="availableUsers"
+          :availableActions="availableActions"
         />
       </div>
-    </template>
-    <template v-else>
-      <p>{{ $t("ProjectOverview.activity.empty") }}</p>
-    </template>
+    </div>
+
+    <div class="content">
+      <template v-if="hasDisplayedLogs">
+        <div v-for="(logs, day) in displayedGroupedLogs" :key="day" class="day-group">
+          <div class="day-title">{{ day }}</div>
+          <ActivityItem
+            v-for="log in logs"
+            :key="log.id"
+            :log="log"
+            :formatTimeAgo="formatTimeAgo"
+            @go-folder="$emit('go-folder', $event)"
+          />
+        </div>
+      </template>
+      <template v-else>
+        <p>{{ $t("ProjectOverview.activity.empty") }}</p>
+      </template>
+    </div>
   </div>
 </template>
 

--- a/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.vue
+++ b/src/components/specific/projects/project-history-activity/ProjectHistoryActivity.vue
@@ -4,14 +4,21 @@
       <h3>{{ $t("ProjectOverview.activity.title") }}</h3>
     </div>
 
-    <BIMDataSearch
-      class="input-search"
-      width="95%"
-      :placeholder="$t('t.search')"
-      v-model="searchText"
-      clear
-      color="primary"
-    />
+    <div class="actions flex">
+      <BIMDataSearch
+        class="input-search"
+        width="95%"
+        :placeholder="$t('t.search')"
+        v-model="searchText"
+        clear
+        color="primary"
+      />
+      <ActivityFilters
+        v-model="filters"
+        :availableUsers="availableUsers"
+        :availableActions="availableActions"
+      />
+    </div>
 
     <template v-if="hasDisplayedLogs">
       <div v-for="(logs, day) in displayedGroupedLogs" :key="day" class="day-group">
@@ -40,6 +47,7 @@ import { useTimeAgo } from "../../../../composables/time.js";
 import ProjectService from "../../../../services/ProjectService.js";
 
 import ActivityItem from "./activity-item/ActivityItem.vue";
+import ActivityFilters from "./activity-filters/ActivityFilters.vue";
 
 export default {
   props: {
@@ -47,6 +55,7 @@ export default {
   },
   components: {
     ActivityItem,
+    ActivityFilters,
   },
   emits: ["go-folder"],
 
@@ -119,24 +128,58 @@ export default {
 
     const displayedGroupedLogs = computed(() => {
       const search = searchText.value.trim().toLowerCase();
+      const f = filters.value;
 
       return sortedLogs.value
-        .filter((log) => !search || log._search.includes(search))
+        .filter((log) => {
+          if (search && !log._search.includes(search)) return false;
+
+          // Types
+          if (f.types.length && !f.types.includes(log.action)) return false;
+
+          // Users
+          if (f.users.length && !f.users.includes(log.user_email)) return false;
+
+          // Date
+          if (f.dateFrom && log.dateObj < f.dateFrom) return false;
+          if (f.dateTo) {
+            const endOfDay = new Date(f.dateTo);
+            endOfDay.setHours(23, 59, 59, 999);
+            if (log.dateObj > endOfDay) return false;
+          }
+
+          return true;
+        })
         .reduce((groups, log) => {
           const day = formatDay(log.dateObj);
-
           groups[day] ??= [];
           groups[day].push(log);
-
           return groups;
         }, {});
     });
+
     const hasDisplayedLogs = computed(() => Object.keys(displayedGroupedLogs.value).length > 0);
+
+    const filters = ref({
+      types: [],
+      users: [],
+      dateFrom: null,
+      dateTo: null,
+    });
+
+    const availableUsers = computed(() => [
+      ...new Set(logs.value.map((l) => l.user_email).filter(Boolean)),
+    ]);
+
+    const availableActions = computed(() => new Set(logs.value.map((l) => l.action)));
 
     return {
       displayedGroupedLogs,
       hasDisplayedLogs,
       searchText,
+      filters,
+      availableUsers,
+      availableActions,
       formatTimeAgo,
     };
   },

--- a/src/components/specific/projects/project-history-activity/activity-filters/ActivityFilters.css
+++ b/src/components/specific/projects/project-history-activity/activity-filters/ActivityFilters.css
@@ -1,0 +1,87 @@
+.activity-filters {
+  position: relative;
+
+  /* Filters button */
+  .activity-filters__btn {
+    gap: 6px;
+    .activity-filters__btn--active {
+      border-color: var(--color-primary);
+      background-color: rgba(47, 55, 74, .05);
+      color: var(--color-primary);
+    }
+    .activity-filters__badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 18px;
+      height: 18px;
+      padding: 0 4px;
+      border-radius: 9px;
+      background: var(--color-primary);
+      color: white;
+      font-size: 10px;
+      font-weight: 600;
+    }
+  }
+
+  /* Panel */
+  .activity-filters__panel {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 3px;
+    z-index: 100;
+    width: 320px;
+    background: var(--color-white);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    overflow: auto;
+    .activity-filters__panel-header {
+      padding: 12px 16px;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--color-primary);
+      border-bottom: 1px solid var(--color-silver-light, #f0f0f0);
+    }
+
+    /* Sections */
+    .activity-filters__section {
+      padding: 12px;
+      .activity-filters__title {
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        margin-bottom: 3px;
+      }
+      .activity-filters__row {
+        padding: 2px 0;
+        font-size: 12px;
+        cursor: pointer;
+        user-select: none;
+
+        &.is-disabled {
+          opacity: 0.4;
+          cursor: default;
+        }
+      }
+    }
+    .activity-filters__date-range {
+      :deep() .not-empty {
+        label {
+          display: none
+        }
+      }
+    }
+
+    /* Footer */
+    .activity-filters__footer {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: var(--spacing-unit);
+      padding: 12px 16px;
+      border-top: 1px solid var(--color-silver-light, #f0f0f0);
+      background: var(--color-white);
+    }
+  }
+}

--- a/src/components/specific/projects/project-history-activity/activity-filters/ActivityFilters.vue
+++ b/src/components/specific/projects/project-history-activity/activity-filters/ActivityFilters.vue
@@ -1,0 +1,232 @@
+<template>
+  <div class="activity-filters">
+    <BIMDataButton
+      color="primary"
+      outline
+      radius
+      class="activity-filters__btn"
+      :class="{ 'activity-filters__btn--active': isOpen || hasActiveFilters }"
+      @click="toggle"
+    >
+      <BIMDataIconFilterList size="xxs" />
+      <span>{{ $t("t.filters") }}</span>
+      <span v-if="activeFilterCount > 0" class="activity-filters__badge">
+        {{ activeFilterCount }}
+      </span>
+    </BIMDataButton>
+
+    <transition name="filters-panel">
+      <div v-if="isOpen" class="activity-filters__panel">
+        <!-- Header -->
+        <div class="activity-filters__panel-header">
+          <span>{{ $t("ProjectOverview.activity.filters.title") }}</span>
+        </div>
+
+        <!-- Types -->
+        <div class="activity-filters__section">
+          <div class="activity-filters__title">
+            {{ $t("ProjectOverview.activity.filters.types") }}
+          </div>
+          <div class="activity-filters__types">
+            <label
+              v-for="type in availableTypes"
+              :key="type.action"
+              class="activity-filters__row flex"
+              :class="{
+                'is-checked': localFilters.types.includes(type.action),
+                'is-disabled': type.disabled,
+              }"
+              @click="!type.disabled && toggleItem(localFilters.types, type.action)"
+            >
+              <BIMDataCheckbox
+                :modelValue="localFilters.types.includes(type.action)"
+                :disabled="type.disabled"
+                @update:modelValue="!type.disabled && toggleItem(localFilters.types, type.action)"
+                margin="0 6px 0 0"
+                @click.stop
+              />
+              <span>{{ $t(type.badgeKey) }}</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Users -->
+        <div class="activity-filters__section">
+          <div class="activity-filters__title">
+            {{ $t("ProjectOverview.activity.filters.users") }}
+          </div>
+          <div class="activity-filters__users">
+            <label
+              v-for="user in availableUsers"
+              :key="user"
+              class="activity-filters__row flex"
+              @click="toggleItem(localFilters.users, user)"
+            >
+              <BIMDataCheckbox
+                :modelValue="localFilters.users.includes(user)"
+                @update:modelValue="toggleItem(localFilters.users, user)"
+                margin="0 6px 0 0"
+                @click.stop
+              />
+              <span>{{ user }}</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Date -->
+        <div class="activity-filters__section">
+          <div class="activity-filters__title">
+            {{ $t("ProjectOverview.activity.filters.period") }}
+          </div>
+          <div class="activity-filters__date-range">
+            <BIMDataDatePicker
+              :placeholder="$t('ProjectOverview.activity.filters.period')"
+              :isDateRange="true"
+              :autoCloseRange="true"
+              :clearButton="true"
+              :modelValue="localFilters.dateFrom"
+              :toDate="localFilters.dateTo"
+              :language="locale"
+              fixedPosition="bottom-left"
+              width="100%"
+              @update:modelValue="localFilters.dateFrom = $event"
+              @to-date-change="localFilters.dateTo = $event"
+              @cleared="
+                localFilters.dateFrom = null;
+                localFilters.dateTo = null;
+              "
+            />
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="activity-filters__footer">
+          <BIMDataButton ghost @click="reset">
+            {{ $t("t.reset") }}
+          </BIMDataButton>
+          <BIMDataButton color="primary" fill @click="apply">
+            {{ $t("t.apply") }}
+          </BIMDataButton>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { ACTION_CONFIG } from "../../../../../config/activity-config.js";
+
+export default {
+  name: "ActivityFilters",
+
+  props: {
+    modelValue: {
+      type: Object,
+      default: () => ({
+        types: [],
+        users: [],
+        dateFrom: null,
+        dateTo: null,
+      }),
+    },
+    availableUsers: {
+      type: Array,
+      default: () => [],
+    },
+    availableActions: {
+      type: Set,
+      default: () => new Set(),
+    },
+  },
+
+  emits: ["update:modelValue"],
+
+  setup(props, { emit }) {
+    const { locale } = useI18n();
+    const isOpen = ref(false);
+
+    const cloneFilters = () => ({
+      ...props.modelValue,
+      dateFrom: props.modelValue.dateFrom ? new Date(props.modelValue.dateFrom) : null,
+      dateTo: props.modelValue.dateTo ? new Date(props.modelValue.dateTo) : null,
+      types: [...props.modelValue.types],
+      users: [...props.modelValue.users],
+    });
+    const localFilters = ref(cloneFilters());
+
+    watch(
+      () => props.modelValue,
+      () => {
+        localFilters.value = cloneFilters();
+      },
+      { deep: true },
+    );
+
+    const availableTypes = computed(() =>
+      Object.entries(ACTION_CONFIG).map(([action, config]) => ({
+        action,
+        badgeKey: config.badgeKey,
+        disabled: props.availableActions.size > 0 && !props.availableActions.has(action),
+      })),
+    );
+
+    const toggleItem = (arr, value) => {
+      const index = arr.indexOf(value);
+      if (index === -1) arr.push(value);
+      else arr.splice(index, 1);
+    };
+
+    const activeFilterCount = computed(() => {
+      const f = props.modelValue;
+      return f.types.length + f.users.length + (f.dateFrom || f.dateTo ? 1 : 0);
+    });
+
+    const hasActiveFilters = computed(() => activeFilterCount.value > 0);
+
+    const toggle = () => {
+      isOpen.value = !isOpen.value;
+      if (isOpen.value) localFilters.value = cloneFilters();
+    };
+
+    const close = () => {
+      isOpen.value = false;
+    };
+
+    const reset = () => {
+      localFilters.value.types = [];
+      localFilters.value.users = [];
+      localFilters.value.dateFrom = null;
+      localFilters.value.dateTo = null;
+    };
+
+    const apply = () => {
+      emit("update:modelValue", {
+        ...localFilters.value,
+        dateFrom: localFilters.value.dateFrom ? new Date(localFilters.value.dateFrom) : null,
+        dateTo: localFilters.value.dateTo ? new Date(localFilters.value.dateTo) : null,
+        types: [...localFilters.value.types],
+        users: [...localFilters.value.users],
+      });
+      isOpen.value = false;
+    };
+
+    return {
+      locale,
+      isOpen,
+      localFilters,
+      availableTypes,
+      activeFilterCount,
+      hasActiveFilters,
+      toggleItem,
+      toggle,
+      close,
+      reset,
+      apply,
+    };
+  },
+};
+</script>
+
+<style scoped src="./ActivityFilters.css"></style>

--- a/src/components/specific/projects/project-history-activity/activity-filters/ActivityFilters.vue
+++ b/src/components/specific/projects/project-history-activity/activity-filters/ActivityFilters.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="activity-filters">
+  <div class="activity-filters" v-click-away="close">
     <BIMDataButton
       color="primary"
       outline

--- a/src/components/specific/projects/project-history-activity/activity-item/ActivityItem.css
+++ b/src/components/specific/projects/project-history-activity/activity-item/ActivityItem.css
@@ -131,7 +131,7 @@
   }
   .red {
     background: rgba(188, 0, 10, 0.1);
-    color: var(--color-danger);
+    color: rgba(188, 0, 10, 1);
   }
   .teal {
     background: rgba(27, 155, 162, 0.1);

--- a/src/components/specific/projects/project-history-activity/activity-item/ActivityItem.vue
+++ b/src/components/specific/projects/project-history-activity/activity-item/ActivityItem.vue
@@ -74,6 +74,28 @@
             {{ $t("ProjectOverview.activity.newNameTitle") }}
             <strong>{{ log.activity.details.newName }}</strong>
           </div>
+
+          <div v-if="log.activity.details.newPath" class="">
+            <div class="detail detail-path flex items-center">
+              <span>{{ $t("ProjectOverview.activity.oldPathTitle") }}</span>
+              <BIMDataTextbox class="primary" :text="log.activity.details.oldPath" width="80%" />
+            </div>
+            <div class="detail detail-path flex items-center mt-2">
+              <BIMDataIconFolderLocation fill color="primary" />
+              <span>{{ $t("ProjectOverview.activity.newPathTitle") }}</span>
+              <BIMDataTextbox
+                class="primary"
+                :text="log.activity.details.newPath"
+                width="80%"
+                @click.stop="
+                  $emit('go-folder', {
+                    id: log.activity.details.folderId,
+                    path: log.activity.details.newPath,
+                  })
+                "
+              />
+            </div>
+          </div>
         </div>
       </transition>
 

--- a/src/config/activity-config.js
+++ b/src/config/activity-config.js
@@ -16,7 +16,7 @@ const PERMISSION_LIST = [
 
 const getFileName = (path) => path?.split("/").pop() || "";
 
-const ACTION_CONFIG = {
+export const ACTION_CONFIG = {
   document_created: {
     actionKey: "ProjectOverview.activity.document_created",
     getTarget: (log) => getFileName(log.description?.path),

--- a/src/config/activity-config.js
+++ b/src/config/activity-config.js
@@ -170,6 +170,14 @@ export const getActivityFromLog = (log) => {
 
   const roleKey = roleList[log.description?.project_role];
 
+  const getParentPath = (path) => path?.split("/").slice(0, -1).join("/") || "";
+
+  const oldPath = log.description?.old_path;
+  const newPath = log.description?.new_path;
+
+  const isMoved = oldPath && newPath && getParentPath(oldPath) !== getParentPath(newPath);
+  const isRenamed = oldPath && newPath && getFileName(oldPath) !== getFileName(newPath);
+
   const newPermissionEntry = PERMISSION_LIST.find(
     (entry) => entry.value === log.description?.new_permission,
   );
@@ -195,10 +203,10 @@ export const getActivityFromLog = (log) => {
       roleKey,
       newPermissionKey,
       oldPermissionKey,
-      oldName: getFileName(log.description?.old_path),
-      newName: getFileName(log.description?.new_path),
-      oldPath: log.description?.old_path,
-      newPath: log.description?.new_path,
+      oldName: !isMoved && isRenamed ? getFileName(oldPath) : null,
+      newName: !isMoved && isRenamed ? getFileName(newPath) : null,
+      oldPath: isMoved ? oldPath : null,
+      newPath: isMoved ? newPath : null,
     },
   };
 };

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -31,6 +31,8 @@
       "empty": "No recent activity",
       "title": "Activity history",
       "folderTitle": "Folder:",
+      "newPathTitle": "New path:",
+      "oldPathTitle": "Old path:",
       "roleTitle": "Role:",
       "newPermissionTitle": "New rights:",
       "oldPermissionTitle": "Old rights:",

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -40,22 +40,25 @@
       "document_deleted": "File deleted:",
       "document_renamed": "File renamed:",
       "document_moved": "File moved:",
-
       "folder_created": "Folder created:",
       "folder_deleted": "Folder deleted:",
       "folder_permissions_updated": "Folder permissions updated:",
       "folder_renamed": "Folder renamed:",
       "folder_moved": "Folder moved:",
-
       "cloud_invitation_sent": "Invitation sent to:",
       "cloud_invitation_canceled": "Invitation canceled for:",
       "cloud_invitation_accepted": "Invitation accepted by:",
       "cloud_invitation_denied": "Invitation denied by:",
-
       "project_invitation_sent": "Project invitation sent to:",
       "project_invitation_canceled": "Project invitation canceled for:",
       "project_invitation_accepted": "Project invitation accepted by:",
       "project_invitation_denied": "Project invitation denied by:",
+      "filters": {
+        "title": "Filters",
+        "types": "Types",
+        "users": "Users",
+        "period": "Period"
+      },
       "roles": {
         "admin": "Administrator",
         "user": "User",
@@ -954,6 +957,7 @@
   "t": {
     "add": "Add",
     "amount": "Amount",
+    "apply": "Apply",
     "archive": "Archive",
     "back": "Back",
     "cancel": "Cancel",
@@ -972,6 +976,7 @@
     "error": "Error",
     "export": "Export",
     "file": "File",
+    "filters": "Filters",
     "folder": "Folder",
     "import": "Import",
     "invalidName": "Invalid name",
@@ -983,6 +988,7 @@
     "open": "Open",
     "or": "or",
     "rename": "Rename",
+    "reset": "Reset",
     "search": "Search",
     "size": "Size",
     "space": "Space",

--- a/src/i18n/lang/fr.json
+++ b/src/i18n/lang/fr.json
@@ -102,6 +102,8 @@
       "empty": "Aucune activité récente",
       "title": "Historique d’activité",
       "folderTitle": "Dossier :",
+      "newPathTitle": "Nouveau chemin :",
+      "oldPathTitle": "Ancien chemin :",
       "roleTitle": "Rôle :",
       "newPermissionTitle": "Nouveaux droits :",
       "oldPermissionTitle": "Anciens droits :",

--- a/src/i18n/lang/fr.json
+++ b/src/i18n/lang/fr.json
@@ -2,6 +2,7 @@
   "t": {
     "add": "Ajouter",
     "amount": "Montant",
+    "apply": "Appliquer",
     "archive": "Archiver",
     "back": "Retour",
     "cancel": "Annuler",
@@ -25,6 +26,7 @@
     "export": "Exporter en BCF",
     "exportXlsx": "Exporter en Excel",
     "file": "Fichier",
+    "filters": "Filtres",
     "folder": "Dossier",
     "hours_ago": "il y a {count} heure | il y a {count} heures",
     "import": "Importer",
@@ -43,6 +45,7 @@
     "project": "Projet",
     "projects": "Projets",
     "rename": "Renommer",
+    "reset": "Réinitialiser",
     "rootFolder": "Dossier racine",
     "save": "Sauvegarder",
     "search": "Rechercher",
@@ -108,22 +111,25 @@
       "document_deleted": "Suppression du fichier :",
       "document_renamed": "Renommage du fichier :",
       "document_moved": "Déplacement du fichier :",
-
       "folder_created": "Création du dossier :",
       "folder_deleted": "Suppression du dossier :",
       "folder_permissions_updated": "Modification des permissions du dossier :",
       "folder_renamed": "Renommage du dossier :",
       "folder_moved": "Déplacement du dossier :",
-
       "cloud_invitation_sent": "Invitation envoyée à :",
       "cloud_invitation_canceled": "Invitation annulée pour :",
       "cloud_invitation_accepted": "Invitation acceptée par :",
       "cloud_invitation_denied": "Invitation refusée par :",
-
       "project_invitation_sent": "Invitation projet envoyée à :",
       "project_invitation_canceled": "Invitation projet annulée pour :",
       "project_invitation_accepted": "Invitation projet acceptée par :",
       "project_invitation_denied": "Invitation projet refusée par :",
+      "filters": {
+        "title": "Filtres",
+        "types": "Types",
+        "users": "Utilisateurs",
+        "period": "Période"
+      },
       "roles": {
         "admin": "Administrateur",
         "user": "Utilisateur",


### PR DESCRIPTION
https://platform-dev-history-activity-filters.bimdata.io

## Description

Add a filter panel to the project activity history, allowing users to filter logs by:
- **Types** — using the existing activity badges (disabled when absent from current project logs)
- **Users** — based on users present in the fetched logs
- **Date range** — via BIMDataDatePicker in range mode

The active filter count is displayed on the filter button.

<img width="389" height="992" alt="image" src="https://github.com/user-attachments/assets/8e82e3a7-c14a-4d97-908f-d05a331b14f6" />


## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] My code follows the code style of this project.
- [ ] I have tested my code.
- [ ] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
