### PR TITLE
[FIX] (folders table): select all handles visible rows only

### DIFF
--- a/src/components/specific/files/folder-table/FoldersTable.vue
+++ b/src/components/specific/files/folder-table/FoldersTable.vue
@@ -9,7 +9,7 @@
     rowKey="id"
     :rowHeight="48"
     :selectable="true"
-    @selection-changed="$emit('selection-changed', $event)"
+    @selection-changed="onSelectionChanged"
     :canDragOverRow="isFolder"
     @row-drop="onRowDrop"
     :placeholder="$t('t.emptyFolder')"
@@ -218,6 +218,18 @@ export default {
       emit("row-drop", { event, data });
     };
 
+    const onSelectionChanged = (selection) => {
+      const displayedRows = filesTable.value?.filesTable?.displayedRows;
+      if (!Array.isArray(displayedRows)) {
+        emit("selection-changed", selection);
+        return;
+      }
+
+      const displayedIds = new Set(displayedRows.map((row) => row?.data?.id).filter(Boolean));
+      const visibleSelection = selection.filter((file) => displayedIds.has(file.id));
+      emit("selection-changed", visibleSelection);
+    };
+
     let nameEditMode;
     watch(
       () => props.files,
@@ -281,6 +293,7 @@ export default {
       formatBytes,
       isFolder,
       onRowDrop,
+      onSelectionChanged,
       onUploadCompleted,
     };
   },


### PR DESCRIPTION
https://platform-dev-selectallhandlesvisiblerowsonly.bimdata.io

Refs: #697

## Description

Filtering the file list does not affect bulk selection actions.

For example, after filtering files by tag and clicking Select all, actions such as deletion are applied to every file rather than only to the filtered results.

Steps to reproduce

Open a project containing multiple files.
Filter the files using a tag.
Click Select all.
Trigger a bulk action, such as Delete.

Actual behavior
All project files are selected and affected, including files that are not displayed by the active filter.

Expected behavior
When a filter is active, Select all should select only the files included in the filtered results.

Impact
This can lead to unintended destructive actions, including the deletion of files that were not visible to the user.

[Clipchamp](https://formitas-my.sharepoint.com/:v:/g/personal/nt_formitas_de/IQCL9dAgqZzaSLXMuskJ_sGFAQcRCKt76fIz2MMd_vX_Uzo?referrer=Outlook.Desktop&referrerScenario=email-linkwithembed)

## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have tested my code.
- [ ] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
