### PR TITLE
fix prevent duplicate role badges

### DIFF
--- a/src/components/specific/users/user-card/UserCard.vue
+++ b/src/components/specific/users/user-card/UserCard.vue
@@ -36,9 +36,8 @@
                 :text="fullName(user) + (isSelf(user) ? ` (${$t('UserCard.self')})` : '')"
               />
               <UserRoleBadge
-                :role="role"
-                :cloudRole="cloudRole"
-                :projectRole="projectRole"
+                :cloudRole="user.cloud_role"
+                :projectRole="user.role"
                 :isSpaceRole="user.in_all_projects"
               />
             </div>
@@ -95,11 +94,11 @@ export default {
     const { isSelf, isSpaceAdmin, isProjectAdmin } = useUser();
 
     const showActionMenu = computed(() => {
-      return !isSelf(props.user) && isSpaceAdmin(props.space) || !isSelf(props.user) && isProjectAdmin(props.project) && props.user.cloud_role !== 100;
+      return (
+        (!isSelf(props.user) && isSpaceAdmin(props.space)) ||
+        (!isSelf(props.user) && isProjectAdmin(props.project) && props.user.cloud_role !== 100)
+      );
     });
-    const role = computed(() => (props.project ? props.user.role : props.user.cloud_role));
-    const cloudRole = computed(() => props.user.cloud_role);
-    const projectRole = computed(() => props.user.role);
 
     const loading = ref(false);
     provide("loading", loading);
@@ -116,9 +115,6 @@ export default {
     return {
       // References
       loading,
-      role,
-      cloudRole,
-      projectRole,
       showActionMenu,
       showDeleteGuard,
       showUpdateForm,

--- a/src/components/specific/users/user-role-badge/UserRoleBadge.vue
+++ b/src/components/specific/users/user-role-badge/UserRoleBadge.vue
@@ -1,20 +1,6 @@
 <template>
   <span class="user-role-badge" :class="`user-role-badge--${roleClass}`">
-    <template v-if="roleName === 'guest'">
-      {{ $t("UserRoleBadge.guest") }}
-    </template>
-    <template v-if="cloudRole === 100">
-      {{ $t(`UserRoleBadge.spaceAdmin`) }}
-    </template>
-    <template v-if="cloudRole !== 100 && projectRole === 100">
-      {{ $t(`UserRoleBadge.projectAdmin`) }}
-    </template>
-    <template v-if="isSpaceRole && roleName === 'spaceUser'">
-      {{ $t(`UserRoleBadge.spaceUser`) }}
-    </template>
-    <template v-if="!isSpaceRole && roleName === 'projectUser'">
-      {{ $t(`UserRoleBadge.projectUser`) }}
-    </template>
+    {{ $t(`UserRoleBadge.${badgeKey}`) }}
   </span>
 </template>
 
@@ -25,10 +11,6 @@ import { SPACE_ROLE } from "../../../../config/spaces.js";
 
 export default {
   props: {
-    role: {
-      type: Number,
-      required: true,
-    },
     cloudRole: {
       type: Number,
       default: null,
@@ -43,24 +25,32 @@ export default {
     },
   },
   setup(props) {
-    const roleName = computed(() => {
-      switch (props.role) {
-        case SPACE_ROLE.ADMIN:
-          return props.cloudRole === 100 ? "spaceAdmin" : "projectAdmin";
-        case SPACE_ROLE.USER:
-          return props.isSpaceRole ? "spaceUser" : "projectUser";
-        case PROJECT_ROLE.GUEST:
-        default:
-          return "guest";
-      }
-    });
+    const roleClass = computed(() =>
+      badgeKey.value.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase(),
+    );
 
-    const roleClass = computed(() => {
-      return roleName.value.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+    const badgeKey = computed(() => {
+      if (props.cloudRole === SPACE_ROLE.ADMIN) {
+        return "spaceAdmin";
+      }
+
+      if (props.projectRole === PROJECT_ROLE.ADMIN) {
+        return "projectAdmin";
+      }
+
+      if (props.isSpaceRole) {
+        return "spaceUser";
+      }
+
+      if (props.projectRole === PROJECT_ROLE.GUEST) {
+        return "guest";
+      }
+
+      return "projectUser";
     });
 
     return {
-      roleName,
+      badgeKey,
       roleClass,
     };
   },


### PR DESCRIPTION
## Description

This PR fixes an issue where multiple role badges could be displayed for the same user (e.g. `Space Admin` and `Space User` at the same time).
The role badge resolution has been simplified by centralizing the decision logic into a single computed property, ensuring that only one badge is displayed according to the user's effective role.

### Changes
- Fix duplicate role badge display.
- Refactor UserRoleBadge to compute a single badgeKey.
- Remove redundant role prop from UserRoleBadge.
- Simplify UserCard by passing only the required role information (cloudRole, projectRole, isSpaceRole).

<img width="389" height="173" alt="image" src="https://github.com/user-attachments/assets/2062dc03-132e-4f22-af59-74ae2079020a" />


## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] My code follows the code style of this project.
- [ ] I have tested my code.
- [ ] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
