### PR TITLE
[FEATURE] Allow to load 2D/3D or 3D beta if at least one is C

### DIFF
--- a/src/components/specific/models/models-table/model-actions-cell/ModelActionsCell.vue
+++ b/src/components/specific/models/models-table/model-actions-cell/ModelActionsCell.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="model-actions-cell" v-click-away="closeMenu">
-    <div v-if="isModelReady" class="actions-btn flex items-center">
+    <div v-if="isModelReady || isModelFragmentsReady" class="actions-btn flex items-center">
       <template v-if="model.type === MODEL_TYPE.META_BUILDING">
         <BIMDataButton color="primary" outline radius icon @click="onClick('view-metaBuilding')">
           <BIMDataIconStructure size="s" />
@@ -26,6 +26,11 @@
             :project="project"
             :model="model"
             :window="window"
+            :tooltip="
+              window === WINDOWS.IFC2D
+                ? $t('ModelActionsCell.view2dUnavailable')
+                : $t('ModelActionsCell.view3dUnavailable')
+            "
           />
         </template>
       </template>
@@ -91,10 +96,9 @@
         />
       </template>
 
-      <template v-if="model.type === MODEL_TYPE.IFC">
+      <template v-if="model.type === MODEL_TYPE.IFC && isModelFragmentsReady">
         <div class="separator"></div>
         <ViewerButton
-          :disabled="!isModelReady"
           :project="project"
           :model="model"
           :window="WINDOWS.FRAGMENTS"
@@ -198,6 +202,7 @@ export default {
     const menu = ref(null);
     const isOpen = ref(false);
     const isModelReady = computed(() => MODEL_STATUS.COMPLETED === props.model.status);
+    const isModelFragmentsReady = computed(() => MODEL_STATUS.COMPLETED === props.model.fragments_status);
 
     const modelDocument = computed(() =>
       handler.get({ nature: FILE_TYPE.DOCUMENT, id: props.model.document_id }),
@@ -285,6 +290,7 @@ export default {
       menu,
       isOpen,
       isModelReady,
+      isModelFragmentsReady,
       menuItems,
       modelDocument,
       MODEL_TYPE,

--- a/src/components/specific/models/models-table/model-actions-cell/ViewerButton.vue
+++ b/src/components/specific/models/models-table/model-actions-cell/ViewerButton.vue
@@ -1,27 +1,29 @@
 <template>
-  <AppLink
-    data-test-id="btn-open-viewer"
-    :data-test-param="window"
-    :disabled="disabled"
-    :to="{
-      name: routeNames.modelViewer,
-      params: {
-        spaceID: project.cloud.id,
-        projectID: project.id,
-        modelIDs: model.id,
-      },
-      query: {
-        window,
-      },
-    }"
-  >
-    <BIMDataButton :disabled="disabled" class="viewer-button" :color="color" outline radius icon>
-      <span>
-        {{ text || window.toUpperCase() }}
-      </span>
-      <slot name="subtext"> </slot>
-    </BIMDataButton>
-  </AppLink>
+  <BIMDataTooltip :text="disabled ? tooltip : ''" position="bottom">
+    <AppLink
+      data-test-id="btn-open-viewer"
+      :data-test-param="window"
+      :disabled="disabled"
+      :to="{
+        name: routeNames.modelViewer,
+        params: {
+          spaceID: project.cloud.id,
+          projectID: project.id,
+          modelIDs: model.id,
+        },
+        query: {
+          window,
+        },
+      }"
+    >
+      <BIMDataButton :disabled="disabled" class="viewer-button" :color="color" outline radius icon>
+        <span>
+          {{ text || window.toUpperCase() }}
+        </span>
+        <slot name="subtext"> </slot>
+      </BIMDataButton>
+    </AppLink>
+  </BIMDataTooltip>
 </template>
 
 <script setup>
@@ -50,6 +52,10 @@ defineProps({
   text: {
     type: String,
   },
+  tooltip: {
+    type: String,
+    default: "",
+  },
   color: {
     type: String,
     default: "granite",
@@ -62,7 +68,7 @@ defineProps({
   color: var(--color-granite-light);
 
   &:disabled {
-    visibility: hidden;
+    opacity: 0.4;
   }
 }
 </style>

--- a/src/components/specific/models/models-table/model-status-cell/ModelStatusCell.vue
+++ b/src/components/specific/models/models-table/model-status-cell/ModelStatusCell.vue
@@ -29,6 +29,17 @@ export default {
     const statusName = ref("");
     const statusIcon = ref("");
 
+    // A model is considered completed as soon as one of its two
+    // status (status and fragments_status) is completed.
+    const globalStatus = (model) =>
+      MODEL_STATUS.COMPLETED === model.status || MODEL_STATUS.COMPLETED === model.fragments_status
+        ? MODEL_STATUS.COMPLETED
+        : model.status;
+
+    const isProcessing = (model) =>
+      [MODEL_STATUS.PENDING, MODEL_STATUS.IN_PROGRESS].includes(model.status) ||
+      [MODEL_STATUS.PENDING, MODEL_STATUS.IN_PROGRESS].includes(model.fragments_status);
+
     const setStatus = (status) => {
       switch (status) {
         case MODEL_STATUS.PENDING:
@@ -53,20 +64,14 @@ export default {
       () => props.model,
       () => {
         clearInterval(checkStatusInterval);
-        setStatus(props.model.status);
+        setStatus(globalStatus(props.model));
 
-        if (
-          MODEL_STATUS.PENDING === props.model.status ||
-          MODEL_STATUS.IN_PROGRESS === props.model.status
-        ) {
+        if (isProcessing(props.model)) {
           // If model status is PENDING or IN_PROGRESS then check for status
           // every 2 seconds until it's neither PENDING nor IN_PROGRESS.
           checkStatusInterval = setInterval(async () => {
             const model = await fetchModelByID(props.project, props.model.id);
-            if (
-              MODEL_STATUS.PENDING !== model.status &&
-              MODEL_STATUS.IN_PROGRESS !== model.status
-            ) {
+            if (!isProcessing(model)) {
               clearInterval(checkStatusInterval);
               loadProjectModels(props.project);
             }

--- a/src/i18n/lang/de.json
+++ b/src/i18n/lang/de.json
@@ -221,7 +221,9 @@
     "userAlreadyExistInputErrorMessage": "Der Nutzer ist bereits in Ihren Projekt."
   },
   "ModelActionsCell": {
-    "addTagsButtonText": "Tags hinzufügen"
+    "addTagsButtonText": "Tags hinzufügen",
+    "view2dUnavailable": "Die 2D-Ansicht ist nicht verfügbar",
+    "view3dUnavailable": "Die 3D-Ansicht ist nicht verfügbar, probieren Sie die Beta"
   },
   "ModelLocation": {
     "emptyLocationMessage": "Keine Ortungsdaten verfügbar",

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -291,7 +291,9 @@
     "userAlreadyExistInputErrorMessage": "User is already in the project"
   },
   "ModelActionsCell": {
-    "addTagsButtonText": "Add tags"
+    "addTagsButtonText": "Add tags",
+    "view2dUnavailable": "The 2D view is not available",
+    "view3dUnavailable": "The 3D view is not available, try the beta"
   },
   "ModelLocation": {
     "emptyLocationMessage": "No location data available",

--- a/src/i18n/lang/es.json
+++ b/src/i18n/lang/es.json
@@ -221,7 +221,9 @@
     "userAlreadyExistInputErrorMessage": "El usuario ya está en su proyecto"
   },
   "ModelActionsCell": {
-    "addTagsButtonText": "Añadir etiquetas"
+    "addTagsButtonText": "Añadir etiquetas",
+    "view2dUnavailable": "La vista 2D no está disponible",
+    "view3dUnavailable": "La vista 3D no está disponible, pruebe la beta"
   },
   "ModelLocation": {
     "emptyLocationMessage": "Datos de seguimiento no disponibles",

--- a/src/i18n/lang/fr.json
+++ b/src/i18n/lang/fr.json
@@ -400,7 +400,9 @@
     "successUserToAdmin": "L'utilisateur a été promu administrateur"
   },
   "ModelActionsCell": {
-    "addTagsButtonText": "Ajouter des tags"
+    "addTagsButtonText": "Ajouter des tags",
+    "view2dUnavailable": "La vue 2D n'est pas disponible",
+    "view3dUnavailable": "La vue 3D n'est pas disponible, essayez la bêta"
   },
   "ModelLocation": {
     "emptyLocationMessage": "Aucune données de localisation disponible",

--- a/src/i18n/lang/it.json
+++ b/src/i18n/lang/it.json
@@ -142,7 +142,9 @@
     "successUserToAdmin": "L'utente è stato promosso ad amministratore"
   },
   "ModelActionsCell": {
-    "addTagsButtonText": "Aggiungi tag"
+    "addTagsButtonText": "Aggiungi tag",
+    "view2dUnavailable": "La vista 2D non è disponibile",
+    "view3dUnavailable": "La vista 3D non è disponibile, prova la beta"
   },
   "ModelLocation": {
     "emptyLocationMessage": "Nessun dato di localizzazione disponibile",

--- a/src/i18n/lang/nl.json
+++ b/src/i18n/lang/nl.json
@@ -138,7 +138,9 @@
     "successNotifText": "Uitnodiging verzonden"
   },
   "ModelActionsCell": {
-    "addTagsButtonText": "Labels toevoegen"
+    "addTagsButtonText": "Labels toevoegen",
+    "view2dUnavailable": "De 2D-weergave is niet beschikbaar",
+    "view3dUnavailable": "De 3D-weergave is niet beschikbaar, probeer de bèta"
   },
   "ModelLocation": {
     "emptyLocationMessage": "Geen locatiegegevens beschikbaar",

--- a/src/i18n/lang/no.json
+++ b/src/i18n/lang/no.json
@@ -138,7 +138,9 @@
     "successNotifText": "Invitasjon sendt"
   },
   "ModelActionsCell": {
-    "addTagsButtonText": "Legg til tags"
+    "addTagsButtonText": "Legg til tags",
+    "view2dUnavailable": "2D-visningen er ikke tilgjengelig",
+    "view3dUnavailable": "3D-visningen er ikke tilgjengelig, prøv betaen"
   },
   "ModelLocation": {
     "emptyLocationMessage": "Ingen plasseringsdata tilgjengelig",


### PR DESCRIPTION
https://platform-dev-modelstatusviewerbuttonsdetailed.bimdata.io

## Description

https://www.figma.com/design/EF3vZHJHAYZURxa5zbEYGC/BIMData-platform?node-id=3311-4742&p=f

Is at least one of `model.status` or `model.fragments_status` is `C`, display the corresponding viewer buttons.

Only `model.status` is C:
<img width="372" height="82" alt="Screenshot 2026-08-25 at 15 52 53" src="https://github.com/user-attachments/assets/6e4cb717-dc46-45cc-bbe0-efc6d55ec329" />

Only `model.fragments_status` is C:
<img width="402" height="120" alt="Screenshot 2026-08-25 at 15 53 12" src="https://github.com/user-attachments/assets/978544ef-74b4-437d-94b8-52254dffa377" />


## Types of changes

<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue) DON'T FORGET TO SEND THE PR INTO RELEASE
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] My code follows the code style of this project.
- [x] I have tested my code.
- [x] My code add or change i18n tokens
- [x] I want to run the tests for the commits of this PR
